### PR TITLE
Fjerne aksjonspunkt eraktivt - alltid true fra backend

### DIFF
--- a/packages/fakta-beregning/src/BeregningFaktaIndex.stories.tsx
+++ b/packages/fakta-beregning/src/BeregningFaktaIndex.stories.tsx
@@ -242,7 +242,6 @@ export const VisningAvOverstyrtAvklarAktiviteterUtenOverstyringsrettighet: Story
     definisjon: FaktaBeregningAvklaringsbehovCode.OVERSTYRING_AV_BEREGNINGSAKTIVITETER,
     status: AksjonspunktStatus.OPPRETTET,
     kanLoses: true,
-    erAktivt: true,
     begrunnelse: undefined,
   };
 
@@ -251,7 +250,6 @@ export const VisningAvOverstyrtAvklarAktiviteterUtenOverstyringsrettighet: Story
     definisjon: FaktaBeregningAvklaringsbehovCode.OVERSTYRING_AV_BEREGNINGSGRUNNLAG,
     status: AksjonspunktStatus.OPPRETTET,
     kanLoses: true,
-    erAktivt: true,
     begrunnelse: undefined,
   };
 

--- a/packages/fakta-beregning/src/components/fellesFaktaForATFLogSN/VurderFaktaBeregningPanel.spec.tsx
+++ b/packages/fakta-beregning/src/components/fellesFaktaForATFLogSN/VurderFaktaBeregningPanel.spec.tsx
@@ -11,14 +11,12 @@ const avklarAktiviteterAp = {
   definisjon: AVKLAR_AKTIVITETER,
   status: AksjonspunktStatus.OPPRETTET,
   kanLoses: true,
-  erAktivt: true,
 } as Aksjonspunkt;
 
 const aksjonspunkter = [
   {
     definisjon: VURDER_FAKTA_FOR_ATFL_SN,
     status: 'OPPR',
-    erAktivt: true,
     kanLoses: true,
   },
 ];

--- a/packages/fakta-beregning/src/components/fellesFaktaForATFLogSN/besteberegningFodendeKvinne/VurderBesteberegningForm.spec.tsx
+++ b/packages/fakta-beregning/src/components/fellesFaktaForATFLogSN/besteberegningFodendeKvinne/VurderBesteberegningForm.spec.tsx
@@ -30,7 +30,6 @@ describe('<VurderBesteberegning>', () => {
       definisjon: OVERSTYRING_AV_BEREGNINGSGRUNNLAG,
       status: 'OPPR',
       kanLoses: true,
-      erAktivt: true,
     };
     const initialValues = VurderBesteberegningForm.buildInitialValues(
       [ap],

--- a/packages/fakta-beregning/src/components/fellesFaktaForATFLogSN/vurderOgFastsettATFL/forms/VurderEtterlonnSluttpakkeForm.spec.tsx
+++ b/packages/fakta-beregning/src/components/fellesFaktaForATFLogSN/vurderOgFastsettATFL/forms/VurderEtterlonnSluttpakkeForm.spec.tsx
@@ -7,7 +7,6 @@ describe('<VurderEtterlonnSluttpakkeForm>', () => {
       status: 'OPPRETTET',
       definisjon: 'VURDER_FAKTA_ATFL_SN',
       kanLoses: true,
-      erAktivt: true,
     };
     const bg = {
       beregningsgrunnlagPeriode: [
@@ -35,7 +34,6 @@ describe('<VurderEtterlonnSluttpakkeForm>', () => {
       status: 'OPPRETTET',
       definisjon: 'VURDER_FAKTA_ATFL_SN',
       kanLoses: true,
-      erAktivt: true,
     };
     const bg = {
       beregningsgrunnlagPeriode: [

--- a/packages/fakta-beregning/testdata/ArbeidMedAAPPåSkjæringstidspunktet.ts
+++ b/packages/fakta-beregning/testdata/ArbeidMedAAPPåSkjæringstidspunktet.ts
@@ -123,6 +123,5 @@ export const aksjonspunkt = [
     toTrinnsBehandling: true,
     aksjonspunktType: 'MANU',
     kanLoses: true,
-    erAktivt: true,
   },
 ];

--- a/packages/fakta-beregning/testdata/ArbeidMedAAPPåSkjæringstidspunktetLøstAksjonspunkt.ts
+++ b/packages/fakta-beregning/testdata/ArbeidMedAAPPåSkjæringstidspunktetLøstAksjonspunkt.ts
@@ -150,7 +150,6 @@ export const aksjonspunkt = [
     toTrinnsBehandling: true,
     aksjonspunktType: 'MANU',
     kanLoses: true,
-    erAktivt: true,
     begrunnelse: 'Denne begrunnelsen skal ikke vises.',
   },
   {
@@ -159,6 +158,5 @@ export const aksjonspunkt = [
     toTrinnsBehandling: true,
     aksjonspunktType: 'MANU',
     kanLoses: true,
-    erAktivt: true,
   },
 ];

--- a/packages/fakta-beregning/testdata/ArbeidMedDagpengerIOpptjeningsperioden.ts
+++ b/packages/fakta-beregning/testdata/ArbeidMedDagpengerIOpptjeningsperioden.ts
@@ -235,6 +235,5 @@ export const aksjonspunkt = [
     toTrinnsBehandling: true,
     aksjonspunktType: 'MANU',
     kanLoses: true,
-    erAktivt: true,
   },
 ];

--- a/packages/fakta-fordel-beregningsgrunnlag/testdata/ArbeidOgGradertNaring.ts
+++ b/packages/fakta-fordel-beregningsgrunnlag/testdata/ArbeidOgGradertNaring.ts
@@ -515,6 +515,5 @@ export const aksjonspunkt = [
     toTrinnsBehandling: true,
     aksjonspunktType: 'MANU',
     kanLoses: true,
-    erAktivt: true,
   },
 ];

--- a/packages/fakta-fordel-beregningsgrunnlag/testdata/NyttArbeidOgNaturalytelse.ts
+++ b/packages/fakta-fordel-beregningsgrunnlag/testdata/NyttArbeidOgNaturalytelse.ts
@@ -516,6 +516,5 @@ export const aksjonspunkt = [
     toTrinnsBehandling: true,
     aksjonspunktType: 'MANU',
     kanLoses: true,
-    erAktivt: true,
   },
 ];

--- a/packages/fakta-fordel-beregningsgrunnlag/testdata/VurderRefusjon.ts
+++ b/packages/fakta-fordel-beregningsgrunnlag/testdata/VurderRefusjon.ts
@@ -84,6 +84,5 @@ export const aksjonspunkt = [
     toTrinnsBehandling: true,
     aksjonspunktType: 'MANU',
     kanLoses: true,
-    erAktivt: true,
   },
 ];

--- a/packages/prosess-tilbakekreving-foreldelse/src/ForeldelseProsessIndex.stories.tsx
+++ b/packages/prosess-tilbakekreving-foreldelse/src/ForeldelseProsessIndex.stories.tsx
@@ -111,7 +111,6 @@ Default.args = {
       status: AksjonspunktStatus.OPPRETTET,
       begrunnelse: undefined,
       kanLoses: true,
-      erAktivt: true,
     },
   ],
 };

--- a/packages/types/src/aksjonspunktTsType.ts
+++ b/packages/types/src/aksjonspunktTsType.ts
@@ -9,7 +9,6 @@ type Aksjonspunkt = Readonly<{
   besluttersBegrunnelse?: string;
   aksjonspunktType?: string;
   kanLoses: boolean;
-  erAktivt: boolean;
   endretAv?: string;
   endretTidspunkt?: string;
 }>;


### PR DESCRIPTION
@tor-nav må visst ta denne før fp-frontend. Kan dere varsle k9-frontend og hjelpe med release ?
K9-sak og begge tilbake setter alltid eraktivt = true fra backend