### PR TITLE
TFP-5265 optional behandlingårsak for klage / tilbake

### DIFF
--- a/packages/sak-behandling-velger/src/components/BehandlingInformasjon.tsx
+++ b/packages/sak-behandling-velger/src/components/BehandlingInformasjon.tsx
@@ -63,7 +63,7 @@ const BehandlingInformasjon: FunctionComponent<OwnProps> = ({
               {getKodeverkMedNavn(behandling.type, KodeverkType.BEHANDLING_TYPE, behandling.type)?.navn || ''}
             </Label>
           </FlexColumn>
-          {behandling.type === BehandlingType.REVURDERING && behandling.førsteÅrsak?.behandlingArsakType && (
+          {(behandling.type === BehandlingType.REVURDERING || behandling.type === BehandlingType.KLAGE) && behandling.førsteÅrsak?.behandlingArsakType && (
             <>
               <FlexColumn className={styles.arsakPadding}>-</FlexColumn>
               <FlexColumn>


### PR DESCRIPTION
Man ønsker gjøre klage på tilbakekreving synlig i meny + los. Disse klagene vil ha en behandlingsårsak, andre klager ikke.
Håper det er bare navikt/ft-sak-behandling-velger som får ny versjon pga denne