### PR TITLE
Vise fagsakmerking for annet enn FP

### DIFF
--- a/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
+++ b/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
@@ -51,16 +51,22 @@ const FagsakProfile: FunctionComponent<OwnProps> = ({
                     <Tag variant="info">{`${dekningsgrad}%`}</Tag>
                   </Tooltip>
                 </FlexColumn>
-                {fagsakMarkeringTekst && (
-                  <FlexColumn>
-                    <Tooltip
-                      content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { fagsakMarkeringTekst })}
-                      alignBottom
-                    >
-                      <Tag variant="alt1">{`${fagsakMarkeringTekst}`}</Tag>
-                    </Tooltip>
-                  </FlexColumn>
-                )}
+              </FlexRow>
+            </FlexContainer>
+          </FlexColumn>
+        )}
+        {fagsakMarkeringTekst && (
+          <FlexColumn>
+            <FlexContainer>
+              <FlexRow>
+                <FlexColumn>
+                  <Tooltip
+                    content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { fagsakMarkeringTekst })}
+                    alignBottom
+                  >
+                    <Tag variant="alt1">{`${fagsakMarkeringTekst}`}</Tag>
+                  </Tooltip>
+                </FlexColumn>
               </FlexRow>
             </FlexContainer>
           </FlexColumn>


### PR DESCRIPTION
Fikk innspill om at saksmerking (Utland, Næring, EØS, etc) ikke vises for ES og SVP.
Det skyldes at visSakDekningsgrad krever FP.

Ønskes: en Row med første kolonne = ytelsesnavn, evt kolonne med Tag/dekningsgrad, evt kolonne med Tag/markering
Litt usikker på om jeg burde pakket inn i en (visSakDekningsgrad || fagsakMarkeringTekst) for å ha de i samme flexcontainer. 
De to <Tag info/alt1 bør ha samme høyde.

Kunne dere hjelpe til med release av ny versjon av sak-fagsak-profil ?