### PR TITLE
Fikser håndtering av overstyring

### DIFF
--- a/packages/fakta-beregning-redesign/package.json
+++ b/packages/fakta-beregning-redesign/package.json
@@ -22,7 +22,7 @@
     "build": "vite build",
     "clean": "rm -rf ./dist ./node_modules ./.storybook-static-build",
     "build-storybook": "storybook build -o .storybook-static-build",
-    "storybook": "storybook dev --quiet -p 7001"
+    "storybook": "storybook dev --quiet -p 7002"
   },
   "dependencies": {
     "@navikt/aksel-icons": "5.12.2",

--- a/packages/fakta-beregning-redesign/src/BeregningFaktaIndex.tsx
+++ b/packages/fakta-beregning-redesign/src/BeregningFaktaIndex.tsx
@@ -43,7 +43,8 @@ type OwnProps = {
   skalKunneAvbryteOverstyring?: boolean;
 };
 
-const { VURDER_FAKTA_FOR_ATFL_SN, AVKLAR_AKTIVITETER } = FaktaBeregningAvklaringsbehovCode;
+const { VURDER_FAKTA_FOR_ATFL_SN, AVKLAR_AKTIVITETER, OVERSTYRING_AV_BEREGNINGSGRUNNLAG } =
+  FaktaBeregningAvklaringsbehovCode;
 
 const erForlengelse = (bg: Beregningsgrunnlag, vilkårsperioder: Vilkarperiode[]) => {
   const vilkårPeriode = vilkårsperioder.find(({ periode }) => periode.fom === bg.vilkårsperiodeFom);
@@ -419,7 +420,8 @@ const BeregningFaktaIndex: FunctionComponent<
         <Heading size="small" level="2">
           <FormattedMessage id="BeregningInfoPanel.AksjonspunktHelpText.SaksopplysningerBeregning" />
         </Heading>
-        {hasAksjonspunkt(VURDER_FAKTA_FOR_ATFL_SN, aktiveAvklaringsBehov) &&
+        {(hasAksjonspunkt(VURDER_FAKTA_FOR_ATFL_SN, aktiveAvklaringsBehov) ||
+          hasAksjonspunkt(OVERSTYRING_AV_BEREGNINGSGRUNNLAG, aktiveAvklaringsBehov)) &&
         !isAksjonspunktClosed(aktiveAvklaringsBehov) ? (
           <>
             <VerticalSpacer sixteenPx />

--- a/packages/fakta-beregning-redesign/src/components/fellesFaktaForATFLogSN/InntektFieldArrayRow.tsx
+++ b/packages/fakta-beregning-redesign/src/components/fellesFaktaForATFLogSN/InntektFieldArrayRow.tsx
@@ -184,7 +184,7 @@ const InntektFieldArrayAndelRow: FunctionComponent<OwnProps> = ({
         </Table.DataCell>
       )}
       {skalViseOverstyrtInntektInput && (
-        <Table.DataCell align="right">
+        <Table.DataCell align="right" className={styles.rightAlignInput}>
           <InputField
             size="small"
             label={intl.formatMessage(

--- a/packages/fakta-beregning-redesign/src/components/fellesFaktaForATFLogSN/vurderOgFastsettATFL/VurderOgFastsettATFL.tsx
+++ b/packages/fakta-beregning-redesign/src/components/fellesFaktaForATFLogSN/vurderOgFastsettATFL/VurderOgFastsettATFL.tsx
@@ -236,7 +236,7 @@ const VurderOgFastsettATFL: FunctionComponent<OwnProps> & StaticFunctions = ({
     if (!vilkarsperiodeSkalVurderesIBehandlingen) {
       return null;
     }
-    if (hasShownPanel && !erOverstyring(formValues)) {
+    if (hasShownPanel) {
       if (readOnly) {
         return (
           <>
@@ -269,14 +269,16 @@ const VurderOgFastsettATFL: FunctionComponent<OwnProps> & StaticFunctions = ({
                 {form}
               </React.Fragment>
             ))}
-            <InntektInputFields
-              beregningsgrunnlag={beregningsgrunnlag}
-              isAksjonspunktClosed={isAksjonspunktClosed}
-              readOnly={readOnly}
-              tilfeller={tilfeller}
-              arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-              kodeverkSamling={kodeverkSamling}
-            />
+            {!erOverstyring(formValues) && (
+              <InntektInputFields
+                beregningsgrunnlag={beregningsgrunnlag}
+                isAksjonspunktClosed={isAksjonspunktClosed}
+                readOnly={readOnly}
+                tilfeller={tilfeller}
+                arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
+                kodeverkSamling={kodeverkSamling}
+              />
+            )}
             {renderTextFieldAndSubmitButton()}
           </AksjonspunktBoks>
         </>


### PR DESCRIPTION
Bakgrunn: Ved overstyring forsvant alle forms med radioknapper og inputfelter. Dette er problematisk fordi da kan ikke enkelte aksjonspunkt løses.

Løsning: Ved overstyriong lastes forms, og enkelte av disse har håndtering for å sette radioknapper til read only som i gammelt design. Alle inputfelter fjernes ettersom overstyring av inntekt fremdeles foregår i tabellen.