### PR TITLE
Flytte dekningsgrad og sakstags (flere) til under saksnummer

### DIFF
--- a/packages/sak-fagsak-profil/i18n/nb_NO.json
+++ b/packages/sak-fagsak-profil/i18n/nb_NO.json
@@ -1,4 +1,4 @@
 {
   "FagsakProfile.Dekningsgrad": "Dekningsgraden er {dekningsgrad}%",
-  "FagsakProfile.FagsakMarkering": "Saken er markert med {fagsakMarkeringTekst}"
+  "FagsakProfile.FagsakMarkering": "Saken er markert med {tekst}"
 }

--- a/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.spec.tsx
+++ b/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.spec.tsx
@@ -9,7 +9,8 @@ describe('<FagsakProfile>', () => {
   it('skal vise fagsak-profil', async () => {
     render(<Default />);
     expect(await screen.findByText('Foreldrepenger')).toBeInTheDocument();
-    expect(screen.getByText('Dekningsgraden er 100%')).toBeInTheDocument();
     expect(screen.getByText('232341251 - Opprettet')).toBeInTheDocument();
+    expect(screen.getByText('Dekningsgraden er 100%')).toBeInTheDocument();
+    expect(screen.getByText('Næring')).toBeInTheDocument();
   });
 });

--- a/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.spec.tsx
+++ b/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.spec.tsx
@@ -9,8 +9,9 @@ describe('<FagsakProfile>', () => {
   it('skal vise fagsak-profil', async () => {
     render(<Default />);
     expect(await screen.findByText('Foreldrepenger')).toBeInTheDocument();
-    expect(screen.getByText('232341251 - Opprettet')).toBeInTheDocument();
     expect(screen.getByText('Dekningsgraden er 100%')).toBeInTheDocument();
+    expect(screen.getByText('232341251 - Opprettet')).toBeInTheDocument();
     expect(screen.getByText('Næring')).toBeInTheDocument();
+    expect(screen.getByText('Utland')).toBeInTheDocument();
   });
 });

--- a/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.stories.tsx
+++ b/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.stories.tsx
@@ -24,7 +24,7 @@ const Template: StoryFn = () => (
         kodeverk: FAGSAK_YTELSE_KODEVERK,
         navn: 'Foreldrepenger',
       }}
-      fagsakMarkeringTekst={['Næring']}
+      fagsakMarkeringTekster={['Næring']}
       fagsakStatus={{ kode: FagsakStatus.OPPRETTET, kodeverk: FAGSAK_STATUS_KODEVERK, navn: 'Opprettet' }}
       dekningsgrad={100}
     />

--- a/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.stories.tsx
+++ b/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.stories.tsx
@@ -24,7 +24,7 @@ const Template: StoryFn = () => (
         kodeverk: FAGSAK_YTELSE_KODEVERK,
         navn: 'Foreldrepenger',
       }}
-      fagsakMarkeringTekst="Næring"
+      fagsakMarkeringTekst={['Næring']}
       fagsakStatus={{ kode: FagsakStatus.OPPRETTET, kodeverk: FAGSAK_STATUS_KODEVERK, navn: 'Opprettet' }}
       dekningsgrad={100}
     />

--- a/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.stories.tsx
+++ b/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.stories.tsx
@@ -24,7 +24,7 @@ const Template: StoryFn = () => (
         kodeverk: FAGSAK_YTELSE_KODEVERK,
         navn: 'Foreldrepenger',
       }}
-      fagsakMarkeringTekster={['Næring']}
+      fagsakMarkeringTekster={['Næring', 'Utland']}
       fagsakStatus={{ kode: FagsakStatus.OPPRETTET, kodeverk: FAGSAK_STATUS_KODEVERK, navn: 'Opprettet' }}
       dekningsgrad={100}
     />

--- a/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.tsx
+++ b/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.tsx
@@ -14,7 +14,7 @@ export interface OwnProps {
   fagsakYtelseType: KodeverkMedNavn;
   fagsakStatus: KodeverkMedNavn;
   dekningsgrad?: number;
-  fagsakMarkeringTekster: string[];
+  fagsakMarkeringTekster?: string[];
 }
 
 const FagsakProfilSakIndex: FunctionComponent<OwnProps> = ({

--- a/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.tsx
+++ b/packages/sak-fagsak-profil/src/FagsakProfilSakIndex.tsx
@@ -14,7 +14,7 @@ export interface OwnProps {
   fagsakYtelseType: KodeverkMedNavn;
   fagsakStatus: KodeverkMedNavn;
   dekningsgrad?: number;
-  fagsakMarkeringTekst?: string;
+  fagsakMarkeringTekster: string[];
 }
 
 const FagsakProfilSakIndex: FunctionComponent<OwnProps> = ({
@@ -22,7 +22,7 @@ const FagsakProfilSakIndex: FunctionComponent<OwnProps> = ({
   fagsakYtelseType,
   fagsakStatus,
   dekningsgrad,
-  fagsakMarkeringTekst,
+  fagsakMarkeringTekster,
 }) => (
   <RawIntlProvider value={intl}>
     <FagsakProfile
@@ -30,7 +30,7 @@ const FagsakProfilSakIndex: FunctionComponent<OwnProps> = ({
       fagsakYtelseType={fagsakYtelseType}
       fagsakStatus={fagsakStatus}
       dekningsgrad={dekningsgrad}
-      fagsakMarkeringTekst={fagsakMarkeringTekst}
+      fagsakMarkeringTekster={fagsakMarkeringTekster}
     />
   </RawIntlProvider>
 );

--- a/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
+++ b/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
@@ -34,31 +34,29 @@ const FagsakProfile: FunctionComponent<OwnProps> = ({
 }) => {
   const intl = useIntl();
   return (
-    <>
-      <VStack gap="4">
-        <HStack gap="4">
-          <Heading size="medium">{fagsakYtelseType.navn}</Heading>
-          {visSakDekningsgrad(fagsakYtelseType.kode, dekningsgrad) && (
-            <Tooltip content={intl.formatMessage({ id: 'FagsakProfile.Dekningsgrad' }, { dekningsgrad })} alignBottom>
-              <Tag variant="info">{`${dekningsgrad}%`}</Tag>
-            </Tooltip>
-          )}
-        </HStack>
-        <BodyShort size="small">{`${saksnummer} - ${fagsakStatus.navn}`}</BodyShort>
-        {fagsakMarkeringTekster && fagsakMarkeringTekster.length > 0 && (
-          <HStack gap="4">
-            {fagsakMarkeringTekster.map((tekst) => (
-              <Tooltip
-                content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { tekst })}
-                alignBottom
-              >
-                <Tag size="small" variant="alt1">{tekst}</Tag>
-              </Tooltip>
-            ))}
-          </HStack>
+    <VStack gap="4">
+      <HStack gap="4">
+        <Heading size="medium">{fagsakYtelseType.navn}</Heading>
+        {visSakDekningsgrad(fagsakYtelseType.kode, dekningsgrad) && (
+          <Tooltip content={intl.formatMessage({ id: 'FagsakProfile.Dekningsgrad' }, { dekningsgrad })} alignBottom>
+            <Tag variant="info">{`${dekningsgrad}%`}</Tag>
+          </Tooltip>
         )}
-      </VStack>
-    </>
+      </HStack>
+      <BodyShort size="small">{`${saksnummer} - ${fagsakStatus.navn}`}</BodyShort>
+      {fagsakMarkeringTekster && fagsakMarkeringTekster.length > 0 && (
+        <HStack gap="4">
+          {fagsakMarkeringTekster.map((tekst) => (
+            <Tooltip
+              content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { tekst })}
+              alignBottom
+            >
+              <Tag size="small" variant="alt1">{tekst}</Tag>
+            </Tooltip>
+          ))}
+        </HStack>
+      )}
+    </VStack>
   );
 };
 

--- a/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
+++ b/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
@@ -38,6 +38,7 @@ const FagsakProfile: FunctionComponent<OwnProps> = ({
       <Heading size="medium">{fagsakYtelseType.navn}</Heading>
       <VerticalSpacer eightPx />
       <BodyShort size="small">{`${saksnummer} - ${fagsakStatus.navn}`}</BodyShort>
+      <VerticalSpacer eightPx />
       <HStack gap="4">
         {visSakDekningsgrad(fagsakYtelseType.kode, dekningsgrad) && (
           <Tooltip content={intl.formatMessage({ id: 'FagsakProfile.Dekningsgrad' }, { dekningsgrad })} alignBottom>

--- a/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
+++ b/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { useIntl } from 'react-intl';
-import { Tag, BodyShort, Heading, HStack } from '@navikt/ds-react';
-import { Tooltip, VerticalSpacer } from '@navikt/ft-ui-komponenter';
+import { Tag, BodyShort, Heading, HStack, VStack } from '@navikt/ds-react';
+import { Tooltip } from '@navikt/ft-ui-komponenter';
 import { KodeverkMedNavn } from '@navikt/ft-types';
 import { FagsakYtelseType } from '@navikt/ft-kodeverk';
 
@@ -47,14 +47,14 @@ const FagsakProfile: FunctionComponent<OwnProps> = ({
         <BodyShort size="small">{`${saksnummer} - ${fagsakStatus.navn}`}</BodyShort>
         {fagsakMarkeringTekster && fagsakMarkeringTekster.length > 0 && (
           <HStack gap="4">
-          fagsakMarkeringTekster.map((tekst) => (
-            <Tooltip
-              content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { tekst })}
-              alignBottom
-            >
-              <Tag size="small" variant="alt1">{tekst}</Tag>
-            </Tooltip>
-          )
+            {fagsakMarkeringTekster.map((tekst) => (
+              <Tooltip
+                content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { tekst })}
+                alignBottom
+              >
+                <Tag size="small" variant="alt1">{tekst}</Tag>
+              </Tooltip>
+            ))}
           </HStack>
         )}
       </VStack>

--- a/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
+++ b/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
@@ -35,26 +35,29 @@ const FagsakProfile: FunctionComponent<OwnProps> = ({
   const intl = useIntl();
   return (
     <>
-      <Heading size="medium">{fagsakYtelseType.navn}</Heading>
-      <VerticalSpacer eightPx />
-      <BodyShort size="small">{`${saksnummer} - ${fagsakStatus.navn}`}</BodyShort>
-      <VerticalSpacer eightPx />
-      <HStack gap="4">
-        {visSakDekningsgrad(fagsakYtelseType.kode, dekningsgrad) && (
-          <Tooltip content={intl.formatMessage({ id: 'FagsakProfile.Dekningsgrad' }, { dekningsgrad })} alignBottom>
-            <Tag size="small" variant="info">{`${dekningsgrad}%`}</Tag>
-          </Tooltip>
+      <VStack gap="4">
+        <HStack gap="4">
+          <Heading size="medium">{fagsakYtelseType.navn}</Heading>
+          {visSakDekningsgrad(fagsakYtelseType.kode, dekningsgrad) && (
+            <Tooltip content={intl.formatMessage({ id: 'FagsakProfile.Dekningsgrad' }, { dekningsgrad })} alignBottom>
+              <Tag variant="info">{`${dekningsgrad}%`}</Tag>
+            </Tooltip>
+          )}
+        </HStack>
+        <BodyShort size="small">{`${saksnummer} - ${fagsakStatus.navn}`}</BodyShort>
+        {fagsakMarkeringTekster && fagsakMarkeringTekster.length > 0 && (
+          <HStack gap="4">
+          fagsakMarkeringTekster.map((tekst) => (
+            <Tooltip
+              content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { tekst })}
+              alignBottom
+            >
+              <Tag size="small" variant="alt1">{tekst}</Tag>
+            </Tooltip>
+          )
+          </HStack>
         )}
-        {fagsakMarkeringTekster && fagsakMarkeringTekster.length > 0 && fagsakMarkeringTekster.map((tekst) => (
-          <Tooltip
-            content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { tekst })}
-            alignBottom
-          >
-            <Tag size="small" variant="alt1">{`${tekst}`}</Tag>
-          </Tooltip>
-        ))
-        }
-      </HStack>
+      </VStack>
     </>
   );
 };

--- a/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
+++ b/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
@@ -17,7 +17,7 @@ export interface OwnProps {
   fagsakYtelseType: KodeverkMedNavn;
   fagsakStatus: KodeverkMedNavn;
   dekningsgrad?: number;
-  fagsakMarkeringTekst?: string;
+  fagsakMarkeringTekster: string[];
 }
 
 /**
@@ -30,29 +30,30 @@ const FagsakProfile: FunctionComponent<OwnProps> = ({
   fagsakYtelseType,
   fagsakStatus,
   dekningsgrad,
-  fagsakMarkeringTekst,
+  fagsakMarkeringTekster,
 }) => {
   const intl = useIntl();
   return (
     <>
-      <HStack gap="4">
-        <Heading size="medium">{fagsakYtelseType.navn}</Heading>
-        {visSakDekningsgrad(fagsakYtelseType.kode, dekningsgrad) && (
-          <Tooltip content={intl.formatMessage({ id: 'FagsakProfile.Dekningsgrad' }, { dekningsgrad })} alignBottom>
-            <Tag variant="info">{`${dekningsgrad}%`}</Tag>
-          </Tooltip>
-        )}
-        {fagsakMarkeringTekst && (
-          <Tooltip
-            content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { fagsakMarkeringTekst })}
-            alignBottom
-          >
-            <Tag variant="alt1">{`${fagsakMarkeringTekst}`}</Tag>
-          </Tooltip>
-        )}
-      </HStack>
+      <Heading size="medium">{fagsakYtelseType.navn}</Heading>
       <VerticalSpacer eightPx />
       <BodyShort size="small">{`${saksnummer} - ${fagsakStatus.navn}`}</BodyShort>
+      <HStack gap="4">
+        {visSakDekningsgrad(fagsakYtelseType.kode, dekningsgrad) && (
+          <Tooltip content={intl.formatMessage({ id: 'FagsakProfile.Dekningsgrad' }, { dekningsgrad })} alignBottom>
+            <Tag size="small" variant="info">{`${dekningsgrad}%`}</Tag>
+          </Tooltip>
+        )}
+        {fagsakMarkeringTekster.length > 0 && fagsakMarkeringTekster.map((tekst) => (
+          <Tooltip
+            content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { tekst })}
+            alignBottom
+          >
+            <Tag size="small" variant="alt1">{`${tekst}`}</Tag>
+          </Tooltip>
+        ))
+        }
+      </HStack>
     </>
   );
 };

--- a/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
+++ b/packages/sak-fagsak-profil/src/components/FagsakProfile.tsx
@@ -17,7 +17,7 @@ export interface OwnProps {
   fagsakYtelseType: KodeverkMedNavn;
   fagsakStatus: KodeverkMedNavn;
   dekningsgrad?: number;
-  fagsakMarkeringTekster: string[];
+  fagsakMarkeringTekster?: string[];
 }
 
 /**
@@ -44,7 +44,7 @@ const FagsakProfile: FunctionComponent<OwnProps> = ({
             <Tag size="small" variant="info">{`${dekningsgrad}%`}</Tag>
           </Tooltip>
         )}
-        {fagsakMarkeringTekster.length > 0 && fagsakMarkeringTekster.map((tekst) => (
+        {fagsakMarkeringTekster && fagsakMarkeringTekster.length > 0 && fagsakMarkeringTekster.map((tekst) => (
           <Tooltip
             content={intl.formatMessage({ id: 'FagsakProfile.FagsakMarkering' }, { tekst })}
             alignBottom


### PR DESCRIPTION
Det jeg prøver å få til: Utvide fra en "tag" til flere tags (Utland, BareFar, Næring) i hver sin aksel-tag på samme linje. 
For å få plass - flytte tags fra øverste linje "Foreldrepenger" (eller annen ytelse) til under Saksnummer