### PR TITLE
forenkle lokalisering av dager og uker til formatert string

### DIFF
--- a/packages/utils/i18n/nb_NO.json
+++ b/packages/utils/i18n/nb_NO.json
@@ -2,13 +2,6 @@
   "Malform.Bokmal": "Bokmål",
   "Malform.Nynorsk": "Nynorsk",
   "Malform.Engelsk": "Engelsk",
-  "UttakInfoPanel.AntallEnDagOgEnUke": "{weeks} uke {days} dag",
-  "UttakInfoPanel.AntallEnDagOgFlereUker": "{weeks} uker {days} dag",
-  "UttakInfoPanel.AntallFlereDagerOgEnUke": "{weeks} uke {days} dager",
-  "UttakInfoPanel.AntallFlereDagerOgFlereUker": "{weeks} uker {days} dager",
-  "UttakInfoPanel.AntallFlereDagerOgNullUker": "{days} dager",
-  "UttakInfoPanel.AntallEnDagOgNullUker": "{days} dag",
-  "UttakInfoPanel.AntallNullDagerOgFlereUker": "{weeks} uker",
-  "UttakInfoPanel.AntallNullDagerOgEnUke": "{weeks} uke",
-  "UttakInfoPanel.TidenesEnde": "Antall uker og dager -"
+  "Dato.AntallDagerOgUker": "{weeks, plural, =0 {} one {# uke}  other {# uker}}{seperator}{days, plural,=0 {} one {# dag} other {# dager}}",
+  "Dato.TidenesEnde": "Antall uker og dager -"
 }

--- a/packages/utils/src/dateUtils.spec.ts
+++ b/packages/utils/src/dateUtils.spec.ts
@@ -1,19 +1,36 @@
+import { expect } from 'vitest';
 import {
   addDaysToDate,
   calcDaysAndWeeks,
   calcDaysAndWeeksWithWeekends,
+  createWeekAndDay,
   dateFormat,
   findDifferenceInMonthsAndDays,
   timeFormat,
 } from './dateUtils';
 
 describe('dateutils', () => {
+  describe('createWeekAndDay', () => {
+    it.each([
+      [1, 1, '1 uke 1 dag'],
+      [2, 2, '2 uker 2 dager'],
+      [4, 0, '4 uker'],
+      [0, 1, '1 dag'],
+      [undefined, 2, '2 dager'],
+      [2, undefined, '2 uker'],
+      [undefined, undefined, 'Antall uker og dager -'],
+    ])('skal formatere %s uker og %s dager ', (uker, dager, expectedString) => {
+      const resultat = createWeekAndDay(uker, dager);
+      expect(resultat.formattedString).toEqual(expectedString);
+    });
+  });
+
   describe('calcDaysAndWeeksWithWeekends', () => {
     it('Skal kalkulere antall dager mellom to datoer inkludert helger og skrive det ut som uker og dager', () => {
       const fom = '2018-04-17';
       const tom = '2018-06-02';
       const formatedMessage = {
-        id: 'UttakInfoPanel.AntallFlereDagerOgFlereUker',
+        id: 'Dato.AntallDagerOgUker',
         formattedString: '6 uker 5 dager',
         weeks: 6,
         days: 5,
@@ -27,7 +44,7 @@ describe('dateutils', () => {
       const fom = '2018-04-17';
       const tom = '2018-06-02';
       const formatedMessage = {
-        id: 'UttakInfoPanel.AntallFlereDagerOgFlereUker',
+        id: 'Dato.AntallDagerOgUker',
         formattedString: '6 uker 4 dager',
         weeks: 6,
         days: 4,

--- a/packages/utils/src/dateUtils.ts
+++ b/packages/utils/src/dateUtils.ts
@@ -16,8 +16,10 @@ const intl = createIntl(messages);
 
 export const TIDENES_ENDE = '9999-12-31';
 
-// Når konsumenter er gått fra å bruke id til å bruke formattedString kan id fjernes
 type WeekAndDay = {
+  /**
+   * @deprecated Når konsumenter er gått fra å bruke id til å bruke formattedString kan id fjernes
+   */
   id: string;
   formattedString: string;
   weeks?: number;
@@ -33,50 +35,34 @@ export const initializeDate = (
   return dayjs(dateString, supportedFormats, strict).utc(true).startOf('day');
 };
 
-const checkDays = (weeks?: number, days?: number): WeekAndDay => {
-  const weeksDaysObj = {
-    weeks,
-    days,
-  };
-
-  let id = 'UttakInfoPanel.AntallFlereDagerOgFlereUker';
-  let formattedString = intl.formatMessage({ id: 'UttakInfoPanel.AntallFlereDagerOgFlereUker' }, { weeks, days });
-
-  if (weeks === undefined && days === undefined) {
-    id = 'UttakInfoPanel.TidenesEnde';
-    formattedString = intl.formatMessage({ id: 'UttakInfoPanel.TidenesEnde' });
-  }
-
-  if (days === 0) {
-    id = weeks === 1 ? 'UttakInfoPanel.AntallNullDagerOgEnUke' : 'UttakInfoPanel.AntallNullDagerOgFlereUker';
-    formattedString = intl.formatMessage({ id }, { weeks });
-  }
-
-  if (weeks === 0) {
-    id = days === 1 ? 'UttakInfoPanel.AntallEnDagOgNullUker' : 'UttakInfoPanel.AntallFlereDagerOgNullUker';
-    formattedString = intl.formatMessage({ id }, { days });
-  }
-
-  if (days === 1) {
-    id = weeks === 1 ? 'UttakInfoPanel.AntallEnDagOgEnUke' : 'UttakInfoPanel.AntallEnDagOgFlereUker';
-    formattedString = intl.formatMessage({ id }, { weeks, days });
-  }
-
-  if (weeks === 1) {
-    id = 'UttakInfoPanel.AntallFlereDagerOgEnUke';
-    formattedString = intl.formatMessage({ id }, { weeks, days });
+export const createWeekAndDay = (weeks?: number, days?: number): WeekAndDay => {
+  let id = 'Dato.AntallDagerOgUker';
+  if (!weeks && !days) {
+    id = 'Dato.TidenesEnde';
+    return {
+      id,
+      formattedString: intl.formatMessage({ id }),
+    };
   }
   return {
     id,
-    formattedString,
-    ...weeksDaysObj,
+    formattedString: intl.formatMessage(
+      { id },
+      {
+        weeks: weeks ?? 0,
+        days: days ?? 0,
+        seperator: days && weeks ? ' ' : '',
+      },
+    ),
+    weeks,
+    days,
   };
 };
 
 export const calcDays = (fraDatoPeriode: string, tilDatoPeriode: string, notWeekends = true): number => {
   if (tilDatoPeriode === TIDENES_ENDE) {
     // @ts-ignore Kva er dette?
-    return checkDays();
+    return createWeekAndDay();
   }
 
   const fraDato = initializeDate(fraDatoPeriode, ISO_DATE_FORMAT);
@@ -111,7 +97,7 @@ export const calcDaysAndWeeks = (fraDatoPeriode: string, tilDatoPeriode: string)
   const weeks = Math.floor(numOfDays / 5);
   const days = numOfDays % 5;
 
-  return checkDays(weeks, days);
+  return createWeekAndDay(weeks, days);
 };
 
 export const calcDaysAndWeeksWithWeekends = (fraDatoPeriode: string, tilDatoPeriode: string): WeekAndDay => {
@@ -122,7 +108,7 @@ export const calcDaysAndWeeksWithWeekends = (fraDatoPeriode: string, tilDatoPeri
   const weeks = Math.floor(numOfDays / 7);
   const days = numOfDays % 7;
 
-  return checkDays(weeks, days);
+  return createWeekAndDay(weeks, days);
 };
 
 export const dateFormat = (date?: Date | string): string => initializeDate(date).format(DDMMYYYY_DATE_FORMAT);


### PR DESCRIPTION
en svakhet i koden gjore at f.eks. `{ weeks:0 og days: 1}` ble formatert til `0 uker og 1 dag`. Dette fikser det.