### PR TITLE
Endrer misvisende navn på prop i datepicker

### DIFF
--- a/packages/form-hooks/src/Datepicker.tsx
+++ b/packages/form-hooks/src/Datepicker.tsx
@@ -1,4 +1,4 @@
-import { DatePicker, useDatepicker } from '@navikt/ds-react';
+import { DatePicker, DatePickerProps, useDatepicker } from '@navikt/ds-react';
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/ft-utils';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
@@ -18,13 +18,12 @@ export interface DatepickerProps {
   disabled?: boolean;
   isReadOnly?: boolean;
   onChange?: (value: any) => void;
-  disabledDays?: {
-    fromDate?: Date;
-    toDate?: Date;
-  };
+  disabledDays?: DatePickerProps['disabled'];
   isEdited?: boolean;
   defaultMonth?: Date;
   size?: 'medium' | 'small';
+  fromDate?: Date;
+  toDate?: Date;
 }
 
 const Datepicker: FunctionComponent<DatepickerProps> = ({
@@ -38,6 +37,8 @@ const Datepicker: FunctionComponent<DatepickerProps> = ({
   disabledDays,
   isEdited,
   defaultMonth,
+  fromDate,
+  toDate,
   size = 'small',
 }) => {
   const {
@@ -66,7 +67,8 @@ const Datepicker: FunctionComponent<DatepickerProps> = ({
       }
     },
     defaultSelected: field.value ? dayjs(field.value, ISO_DATE_FORMAT, true).toDate() : undefined,
-    defaultMonth: defaultMonth || (!field.value && disabledDays?.toDate ? disabledDays.toDate : undefined),
+    defaultMonth: defaultMonth || (!field.value && toDate ? toDate : undefined),
+    disabled: disabledDays,
   });
 
   const onChangeInput = useCallback(
@@ -96,8 +98,8 @@ const Datepicker: FunctionComponent<DatepickerProps> = ({
 
   const dpProps = {
     ...datepickerProps,
-    fromDate: disabledDays?.fromDate,
-    toDate: disabledDays?.toDate,
+    fromDate: fromDate,
+    toDate: toDate,
   };
 
   return (

--- a/packages/form-hooks/src/FormHooks.stories.tsx
+++ b/packages/form-hooks/src/FormHooks.stories.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { useForm } from 'react-hook-form';
-import { StoryFn } from '@storybook/react';
 import { VerticalSpacer } from '@navikt/ft-ui-komponenter';
-import { TextAreaField, SelectField, CheckboxField, InputField } from '../index';
-import Form from './Form';
-import RadioGroupPanel from './RadioGroupPanel';
+import { StoryFn } from '@storybook/react';
+import { useForm } from 'react-hook-form';
+import { CheckboxField, InputField, SelectField, TextAreaField } from '../index';
 import CheckboxPanel from './CheckboxPanel';
-import Rangepicker from './Rangepicker';
 import Datepicker from './Datepicker';
+import Form from './Form';
+import React from 'react';
+import RadioGroupPanel from './RadioGroupPanel';
+import Rangepicker from './Rangepicker';
 
 import styles from './formHooks.stories.module.css';
 
@@ -241,10 +241,8 @@ const Template: StoryFn = () => {
         label="Dette er en datepicker"
         name="datepickerField"
         description="Dette er en mer utfyllende tekst"
-        disabledDays={{
-          fromDate: new Date('2022-10-10'),
-          toDate: new Date('2022-10-14'),
-        }}
+        fromDate={new Date('2022-10-10')}
+        toDate={new Date('2022-10-14')}
       />
       <VerticalSpacer sixteenPx />
       <Datepicker label="Dette er en datepicker der verdi er valgt" name="datepickerFieldPre" />

--- a/packages/form-hooks/src/Rangepicker.tsx
+++ b/packages/form-hooks/src/Rangepicker.tsx
@@ -1,9 +1,9 @@
-import React, { FunctionComponent, ReactNode, useCallback, useMemo, useState } from 'react';
-import { useFormContext, useController } from 'react-hook-form';
-import customParseFormat from 'dayjs/plugin/customParseFormat';
-import dayjs from 'dayjs';
-import { Label, DatePicker, useRangeDatepicker, VStack, HStack } from '@navikt/ds-react';
+import { DatePicker, HStack, Label, useRangeDatepicker, VStack } from '@navikt/ds-react';
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/ft-utils';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import React, { FunctionComponent, ReactNode, useCallback, useMemo, useState } from 'react';
+import { useController, useFormContext } from 'react-hook-form';
 
 import { getError, getValidationRules } from './formUtils';
 import ReadOnlyField from './ReadOnlyField';
@@ -18,10 +18,8 @@ export interface RangepickerProps {
   disabled?: boolean;
   isReadOnly?: boolean;
   onChange?: (value: any) => void;
-  disabledDays?: {
-    fromDate?: Date;
-    toDate?: Date;
-  };
+  fromDate?: Date;
+  toDate?: Date;
   isEdited?: boolean;
 }
 
@@ -33,7 +31,8 @@ const Rangepicker: FunctionComponent<RangepickerProps> = ({
   disabled = false,
   isReadOnly = false,
   onChange,
-  disabledDays,
+  fromDate,
+  toDate,
   isEdited,
 }): JSX.Element => {
   const {
@@ -117,8 +116,8 @@ const Rangepicker: FunctionComponent<RangepickerProps> = ({
 
   const dpProps = {
     ...datepickerProps,
-    fromDate: disabledDays?.fromDate,
-    toDate: disabledDays?.toDate,
+    fromDate: fromDate,
+    toDate: toDate,
   };
 
   return (

--- a/packages/prosess-tilbakekreving-foreldelse/src/components/ForeldelsePeriodeForm.tsx
+++ b/packages/prosess-tilbakekreving-foreldelse/src/components/ForeldelsePeriodeForm.tsx
@@ -99,7 +99,8 @@ const ForeldelsePeriodeForm: FunctionComponent<OwnProps> = ({
               label={intl.formatMessage({ id: 'ForeldelsePeriodeForm.OppdagelsesDato' })}
               validate={[required, hasValidDate, dateBeforeOrEqualToToday]}
               isReadOnly={readOnly}
-              disabledDays={{ fromDate: dayjs('1970-01-01').toDate(), toDate: dayjs().toDate() }}
+              fromDate={dayjs('1970-01-01').toDate()}
+              toDate={dayjs().toDate()}
             />
           )}
         </VStack>

--- a/packages/prosess-tilbakekreving-foreldelse/src/components/splittePerioder/DelOppPeriodeModal.tsx
+++ b/packages/prosess-tilbakekreving-foreldelse/src/components/splittePerioder/DelOppPeriodeModal.tsx
@@ -102,7 +102,8 @@ const DelOppPeriodeModal: FunctionComponent<PureOwnProps> = ({
             name="forstePeriodeTomDato"
             label={<FormattedMessage id="DelOppPeriodeModalImpl.AngiTomDato" />}
             validate={[required, hasValidDate, validerMotPeriode(periodeData, intl)]}
-            disabledDays={{ fromDate: moment(periodeData.fom).toDate(), toDate: moment(periodeData.tom).toDate() }}
+            fromDate={moment(periodeData.fom).toDate()}
+            toDate={moment(periodeData.tom).toDate()}
           />
           {finnesBelopMed0Verdi && (
             <Alert variant="error">

--- a/packages/prosess-tilbakekreving/src/components/splittePerioder/DelOppPeriodeModal.tsx
+++ b/packages/prosess-tilbakekreving/src/components/splittePerioder/DelOppPeriodeModal.tsx
@@ -1,12 +1,12 @@
-import React, { FunctionComponent } from 'react';
-import { FormattedMessage, useIntl, IntlShape } from 'react-intl';
-import { useForm } from 'react-hook-form';
+import { Alert, BodyShort, Button, Heading, Label, Modal } from '@navikt/ds-react';
 import moment from 'moment/moment';
-import { Modal, Button, Label, BodyShort, Alert, Heading } from '@navikt/ds-react';
+import React, { FunctionComponent } from 'react';
+import { useForm } from 'react-hook-form';
+import { FormattedMessage, IntlShape, useIntl } from 'react-intl';
 
+import { Datepicker, Form } from '@navikt/ft-form-hooks';
 import { dateAfterOrEqual, dateBeforeOrEqual, hasValidDate, required } from '@navikt/ft-form-validators';
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '@navikt/ft-utils';
-import { Datepicker, Form } from '@navikt/ft-form-hooks';
 
 import { VerticalSpacer } from '@navikt/ft-ui-komponenter';
 import styles from './delOppPeriodeModal.module.css';
@@ -102,7 +102,8 @@ const DelOppPeriodeModal: FunctionComponent<OwnProps> = ({
             name="forstePeriodeTomDato"
             label={<FormattedMessage id="DelOppPeriodeModalImpl.AngiTomDato" />}
             validate={[required, hasValidDate, validerMotPeriode(periodeData, intl)]}
-            disabledDays={{ fromDate: moment(periodeData.fom).toDate(), toDate: moment(periodeData.tom).toDate() }}
+            fromDate={moment(periodeData.fom).toDate()}
+            toDate={moment(periodeData.tom).toDate()}
           />
           {finnesBelopMed0Verdi && (
             <Alert variant="error">


### PR DESCRIPTION
Gammel bruk av `disabledDays` satt dager utenfor perioden oppgitt i `disabledDays` til disabled. Endret til at disabledDays faktisk spesifiserer datoer som skal være disabled. La til `fromDate` og `toDate` som props for å spesifisere perioden som det evt skal begrenses til å kunne velge