### PR TITLE
Forbedring av DateTimeLabel

### DIFF
--- a/packages/sak-behandling-velger/src/components/BehandlingInformasjon.tsx
+++ b/packages/sak-behandling-velger/src/components/BehandlingInformasjon.tsx
@@ -1,9 +1,8 @@
 import React, { FunctionComponent } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import classNames from 'classnames';
 import { ChevronDownIcon, ChevronUpIcon, StarFillIcon } from '@navikt/aksel-icons';
-import { BodyShort, Label, Detail, HStack, Spacer, VStack, Box } from '@navikt/ds-react';
-import { Tooltip, DateLabel, TimeLabel, VerticalSpacer } from '@navikt/ft-ui-komponenter';
+import { BodyShort, Label, HStack, Spacer, VStack, Box } from '@navikt/ds-react';
+import { Tooltip, VerticalSpacer, DateTimeLabel } from '@navikt/ft-ui-komponenter';
 import { BehandlingAppKontekst, KodeverkMedNavn } from '@navikt/ft-types';
 import { KodeverkType, BehandlingType, BehandlingArsakType } from '@navikt/ft-kodeverk';
 
@@ -126,15 +125,9 @@ const BehandlingInformasjon: FunctionComponent<OwnProps> = ({
             </BodyShort>
           </div>
           <div>
-            <BodyShort size="small" className={styles.inline}>
-              <DateLabel dateString={behandling.opprettet} />
+            <BodyShort size="small">
+              <DateTimeLabel dateTimeString={behandling.opprettet} separator="kl" />
             </BodyShort>
-            <Detail size="small" className={classNames(styles.inline, styles.timePadding)}>
-              <FormattedMessage id="DateTimeLabel.Kl" />
-            </Detail>
-            <Detail size="small" className={styles.inline}>
-              <TimeLabel dateTimeString={behandling.opprettet} />
-            </Detail>
           </div>
         </HStack>
         <HStack>
@@ -145,17 +138,9 @@ const BehandlingInformasjon: FunctionComponent<OwnProps> = ({
           </div>
           <div>
             {behandling.avsluttet && (
-              <>
-                <BodyShort size="small" className={styles.inline}>
-                  <DateLabel dateString={behandling.avsluttet} />
-                </BodyShort>
-                <Detail size="small" className={classNames(styles.inline, styles.timePadding)}>
-                  <FormattedMessage id="DateTimeLabel.Kl" />
-                </Detail>
-                <Detail size="small" className={styles.inline}>
-                  <TimeLabel dateTimeString={behandling.avsluttet} />
-                </Detail>
-              </>
+              <BodyShort size="small">
+                <DateTimeLabel dateTimeString={behandling.avsluttet} separator="kl" />
+              </BodyShort>
             )}
           </div>
           <div className={styles.pushRightCorner}>

--- a/packages/ui-komponenter/i18n/nb_NO.json
+++ b/packages/ui-komponenter/i18n/nb_NO.json
@@ -16,7 +16,7 @@
 
   "PeriodFieldArray.LeggTilPeriode": "Legg til periode",
 
-  "DateTimeLabel.Kl": " Kl.",
+  "DateTimeLabel.Kl": " kl.",
 
   "ExpandableTableRow.Apne": "Åpne rad",
   "ExpandableTableRow.Lukke": "Lukk rad",

--- a/packages/ui-komponenter/src/DateTimeLabel.stories.tsx
+++ b/packages/ui-komponenter/src/DateTimeLabel.stories.tsx
@@ -4,11 +4,12 @@ import { RawIntlProvider } from 'react-intl';
 import { createIntl } from '@navikt/ft-utils';
 
 import DateTimeLabel from './DateTimeLabel';
-import { StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 
 const intl = createIntl({});
 
-export default {
+const meta: Meta<typeof DateTimeLabel> = {
+  title: 'DateTimeLabel',
   component: DateTimeLabel,
   decorators: Story => (
     <RawIntlProvider value={intl}>
@@ -41,3 +42,5 @@ export const MedTilpassetUtrykk: Story = {
     second: '2-digit',
   },
 };
+
+export default meta;

--- a/packages/ui-komponenter/src/DateTimeLabel.stories.tsx
+++ b/packages/ui-komponenter/src/DateTimeLabel.stories.tsx
@@ -4,26 +4,40 @@ import { RawIntlProvider } from 'react-intl';
 import { createIntl } from '@navikt/ft-utils';
 
 import DateTimeLabel from './DateTimeLabel';
+import { StoryObj } from '@storybook/react';
 
-const intl = createIntl({
-  'OkAvbrytModal.Ok': 'Ok',
-  'OkAvbrytModal.Avbryt': 'Avbryt',
-  'Test.Test': 'Dette er ein test',
-});
+const intl = createIntl({});
 
 export default {
-  title: 'DateTimeLabel',
   component: DateTimeLabel,
+  decorators: Story => (
+    <RawIntlProvider value={intl}>
+      <Story />
+    </RawIntlProvider>
+  ),
+  argTypes: {
+    year: { control: 'radio', options: ['numeric', '2-digit', undefined] },
+    month: { control: 'radio', options: ['numeric', '2-digit', 'long', 'short', 'narrow', undefined] },
+    day: { control: 'radio', options: ['numeric', '2-digit', undefined] },
+    hour: { control: 'radio', options: ['numeric', '2-digit', undefined] },
+    minute: { control: 'radio', options: ['numeric', '2-digit', undefined] },
+    second: { control: 'radio', options: ['numeric', '2-digit', undefined] },
+    dateTimeString: { control: 'date' },
+  },
+  args: {
+    dateTimeString: '2024-08-02T10:54:00',
+  },
 };
 
-export const Default = () => (
-  <RawIntlProvider value={intl}>
-    <DateTimeLabel dateTimeString="2017-08-02T00:54:25.455" />
-  </RawIntlProvider>
-);
+type Story = StoryObj<typeof DateTimeLabel>;
 
-export const NyttFormat = () => (
-  <RawIntlProvider value={intl}>
-    <DateTimeLabel dateTimeString="2017-08-02T00:54:25.455" useNewFormat />
-  </RawIntlProvider>
-);
+export const Default: Story = {};
+
+export const MedTilpassetUtrykk: Story = {
+  args: {
+    separator: 'kl',
+    day: 'numeric',
+    month: 'long',
+    second: '2-digit',
+  },
+};

--- a/packages/ui-komponenter/src/DateTimeLabel.tsx
+++ b/packages/ui-komponenter/src/DateTimeLabel.tsx
@@ -7,10 +7,12 @@ import messages from '../i18n/nb_NO.json';
 
 const intl = createIntl(messages);
 
-export interface OwnProps {
+type DateTimeSeperator = 'dash' | 'kl';
+
+export type OwnProps = {
   dateTimeString: string;
-  useNewFormat?: boolean;
-}
+  separator?: DateTimeSeperator;
+} & Intl.DateTimeFormatOptions;
 
 /**
  * DateTimeLabel
@@ -22,22 +24,32 @@ export interface OwnProps {
  * <DateTimeLabel dateTimeString="2017-08-02T00:54:25.455" />
  * ```
  */
-const DateTimeLabel: FunctionComponent<OwnProps> = ({ dateTimeString, useNewFormat = false }) => (
-  <>
-    <FormattedDate day="2-digit" month="2-digit" year="numeric" value={new Date(dateTimeString)} />
-    {!useNewFormat && (
-      <>
-        -
-        <FormattedTime value={new Date(dateTimeString)} />
-      </>
-    )}
-    {useNewFormat && (
-      <>
-        {intl.formatMessage({ id: 'DateTimeLabel.Kl' })}
-        <FormattedTime value={new Date(dateTimeString)} hour="numeric" minute="numeric" second="numeric" />
-      </>
-    )}
-  </>
-);
+const DateTimeLabel: FunctionComponent<OwnProps> = ({
+  dateTimeString,
+  separator = 'dash' as DateTimeSeperator,
+  year = 'numeric',
+  month = '2-digit',
+  day = '2-digit',
+  hour = 'numeric',
+  minute = 'numeric',
+  second = undefined,
+}: OwnProps) => {
+  const getSeparator = () => {
+    switch (separator) {
+      case 'dash':
+        return ' - ';
+      case 'kl':
+        return intl.formatMessage({ id: 'DateTimeLabel.Kl' });
+    }
+  };
+
+  return (
+    <>
+      <FormattedDate value={new Date(dateTimeString)} day={day} month={month} year={year} />
+      {getSeparator()}
+      <FormattedTime value={new Date(dateTimeString)} hour={hour} minute={minute} second={second} />
+    </>
+  );
+};
 
 export default DateTimeLabel;

--- a/packages/ui-komponenter/tsconfig.json
+++ b/packages/ui-komponenter/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["./", "../../@types/externals.d.ts"],
-  "exclude": ["node_modules", "**.spec.ts", "dist"],
+  "exclude": ["node_modules", "**/*.spec.ts*", "dist","**/*.stories.*"],
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "strict": true


### PR DESCRIPTION
Denne komponenten brukes ikke så mye, men har potensial til å brukes en del. 

Her har jeg lagt til litt muligheter for litt tilpassing, men default funksjonaliteten fortsatt består. 

Jeg har fjernet `useNewFormat?: boolean;` og erstattet den med `separator?: 'dash' | 'kl' `som defaulter til dash slik at man beholder samme gamle funksjonalitet. (Men jeg har enda ikke funnet noen av våre team som bruker den propen 😅). Jeg tenker likevel jeg kan oppdatere minor-version på pakken.

Jeg har søkt litt i koden til k9 og fp og det ser kun ut som at det er fp som bruker denne komponenten fra dette repoet. Men jeg ser at det finnes mange identiske DateTimeLabel-komponenter i begge team sine repoer, så det kan være en ide og gå over til disse om man vil slette duplikatene.