### PR TITLE
FAGSYSTEM-352550: Skal tillate å submitte aksjonspunkt på nytt etter det er utført

### DIFF
--- a/packages/fakta-beregning/src/components/fellesFaktaForATFLogSN/VurderFaktaBeregningField.tsx
+++ b/packages/fakta-beregning/src/components/fellesFaktaForATFLogSN/VurderFaktaBeregningField.tsx
@@ -114,11 +114,7 @@ const VurderFaktaBeregningField: FunctionComponent<OwnProps> = ({
             isSubmittable={
               erSubmittable(
                 submittable &&
-                  harIkkeEndringerIAvklarMedFlereAksjonspunkter(
-                    verdiForAvklarAktivitetErEndret,
-                    avklaringsbehovListe,
-                  ) &&
-                  !isAksjonspunktClosed(avklaringsbehovListe),
+                  harIkkeEndringerIAvklarMedFlereAksjonspunkter(verdiForAvklarAktivitetErEndret, avklaringsbehovListe),
                 true,
                 finnesFeilForBegrunnelse(beregningsgrunnlagIndeks, errors),
               ) && !verdiForAvklarAktivitetErEndret


### PR DESCRIPTION
Fikk en sak i porten om at en saksbehandler ikke kommer videre i beregning etter å ha fått tilbake saken fra beslutter.
Gravde litt i det og ser at submit-knappen er disabled på grunn av at det aktuelle aksjonspunktet står som UTFO og ikke OPPR.

Men det skal da vel alltid være mulig gjøre endringer på et aksjonspunkt selv om det er løst fra før av? Er det noen grunn til at denne sjekken er her?

