### PR TITLE
FAGSYSTEM-351021 - Sender ned riktig index for field

### DIFF
--- a/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetAktivitet.tsx
+++ b/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetAktivitet.tsx
@@ -252,7 +252,7 @@ const TilkommetAktivitet: FC<TilkommetAktivitetProps> = ({
           }}
           setDataOnUnmount={setFormData}
         >
-          {fields.map(field => {
+          {fields.map((field, formFieldIndex) => {
             const beregningsgrunnlagIndeks = beregningsgrunnlagListe.findIndex(
               bg => bg.skjaeringstidspunktBeregning === field.beregningsgrunnlagStp,
             );
@@ -265,7 +265,7 @@ const TilkommetAktivitet: FC<TilkommetAktivitetProps> = ({
                 <TilkommetAktivitetPanel
                   formName={FORM_NAME}
                   beregningsgrunnlag={beregningsgrunnlagListe[beregningsgrunnlagIndeks]}
-                  bgIndex={beregningsgrunnlagIndeks}
+                  formFieldIndex={formFieldIndex}
                   readOnly={
                     readOnly ||
                     !vurderesIBehandlingen(

--- a/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetAktivitetAccordion.tsx
+++ b/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetAktivitetAccordion.tsx
@@ -48,7 +48,7 @@ type TilkommetAktivitetAccordionType = {
   beregningsgrunnlag: Beregningsgrunnlag;
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
   formName: string;
-  bgIndex: number;
+  formFieldIndex: number;
   readOnly: boolean;
   submittable: boolean;
   erAksjonspunktÅpent: boolean;
@@ -59,7 +59,7 @@ const TilkommetAktivitetAccordion: FC<TilkommetAktivitetAccordionType> = ({
   beregningsgrunnlag,
   arbeidsgiverOpplysningerPerId,
   formName,
-  bgIndex,
+  formFieldIndex,
   readOnly,
   submittable,
   erAksjonspunktÅpent,
@@ -145,7 +145,7 @@ const TilkommetAktivitetAccordion: FC<TilkommetAktivitetAccordionType> = ({
                 arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
                 vurderInntektsforholdPeriode={finnMatchendeinntektsperiodeForField(field.fom)}
                 formName={formName}
-                bgIndex={bgIndex}
+                formFieldIndex={formFieldIndex}
                 periodeFieldIndex={index}
                 readOnly={readOnly}
                 erAksjonspunktÅpent={erAksjonspunktÅpent}
@@ -161,7 +161,7 @@ const TilkommetAktivitetAccordion: FC<TilkommetAktivitetAccordionType> = ({
         <div className={styles.aktivitetContainer}>
           <VerticalSpacer fourtyPx />
           <TextAreaField
-            name={`${formName}.${bgIndex}.begrunnelse`}
+            name={`${formName}.${formFieldIndex}.begrunnelse`}
             label="Begrunnelse for alle perioder"
             readOnly={readOnly}
             validate={[required]}

--- a/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetAktivitetField.tsx
+++ b/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetAktivitetField.tsx
@@ -21,7 +21,7 @@ import { AssessedBy } from '@navikt/ft-plattform-komponenter';
 type TilkommetAktivitetFieldType = {
   formName: string;
   vurderInntektsforholdPeriode: VurderInntektsforholdPeriode;
-  bgIndex: number;
+  formFieldIndex: number;
   periodeFieldIndex: number;
   readOnly: boolean;
   submittable: boolean;
@@ -40,7 +40,7 @@ export function getPeriodeIdentikator(vurderInntektsforholdPeriode: VurderInntek
 const TilkommetAktivitetField: FC<TilkommetAktivitetFieldType> = ({
   formName,
   vurderInntektsforholdPeriode,
-  bgIndex,
+  formFieldIndex,
   periodeFieldIndex,
   readOnly,
   erAksjonspunktÅpent,
@@ -52,7 +52,7 @@ const TilkommetAktivitetField: FC<TilkommetAktivitetFieldType> = ({
   const { control, formState } = useFormContext<TilkommetAktivitetFormValues>();
   const { fields } = useFieldArray({
     control,
-    name: `VURDER_TILKOMMET_AKTIVITET_FORM.${bgIndex}.perioder.${periodeFieldIndex}.inntektsforhold`,
+    name: `VURDER_TILKOMMET_AKTIVITET_FORM.${formFieldIndex}.perioder.${periodeFieldIndex}.inntektsforhold`,
   });
 
   const harInntektsforholdMedÅrsinntekt = vurderInntektsforholdPeriode.inntektsforholdListe.some(
@@ -138,7 +138,7 @@ const TilkommetAktivitetField: FC<TilkommetAktivitetFieldType> = ({
             <TilkommetInntektsforholdField
               key={field.id}
               formName={formName}
-              bgIndex={bgIndex}
+              formFieldIndex={formFieldIndex}
               periodeFieldIndex={periodeFieldIndex}
               inntektsforholdFieldIndex={index}
               field={field}
@@ -152,7 +152,7 @@ const TilkommetAktivitetField: FC<TilkommetAktivitetFieldType> = ({
           <>
             <VerticalSpacer fourtyPx />
             <TextAreaField
-              name={`${formName}.${bgIndex}.begrunnelse`}
+              name={`${formName}.${formFieldIndex}.begrunnelse`}
               label="Begrunnelse"
               readOnly={readOnly}
               validate={[required]}

--- a/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetAktivitetPanel.tsx
+++ b/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetAktivitetPanel.tsx
@@ -27,7 +27,7 @@ const finnAktivitetStatus = (
 type TilkommetAktivitetPanelType = {
   formName: string;
   beregningsgrunnlag: Beregningsgrunnlag;
-  bgIndex: number;
+  formFieldIndex: number;
   readOnly: boolean;
   submittable: boolean;
   erAksjonspunktÅpent: boolean;
@@ -37,7 +37,7 @@ type TilkommetAktivitetPanelType = {
 const TilkommetAktivitetPanel: FC<TilkommetAktivitetPanelType> = ({
   formName,
   beregningsgrunnlag,
-  bgIndex,
+  formFieldIndex,
   readOnly,
   submittable,
   erAksjonspunktÅpent,
@@ -49,7 +49,7 @@ const TilkommetAktivitetPanel: FC<TilkommetAktivitetPanelType> = ({
   const { control, watch } = useFormContext<TilkommetAktivitetFormValues>();
   const { fields, remove, insert } = useFieldArray({
     control,
-    name: `VURDER_TILKOMMET_AKTIVITET_FORM.${bgIndex}.perioder`,
+    name: `VURDER_TILKOMMET_AKTIVITET_FORM.${formFieldIndex}.perioder`,
   });
   fields.sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom)));
 
@@ -122,10 +122,10 @@ const TilkommetAktivitetPanel: FC<TilkommetAktivitetPanelType> = ({
     andelFieldIndex: number,
   ) => {
     const skalRedusereValg = watch(
-      `${formName}.${bgIndex}.perioder.${periodeFieldIndex}.inntektsforhold.${andelFieldIndex}.skalRedusereUtbetaling`,
+      `${formName}.${formFieldIndex}.perioder.${periodeFieldIndex}.inntektsforhold.${andelFieldIndex}.skalRedusereUtbetaling`,
     );
     const bruttoVerdi = watch(
-      `${formName}.${bgIndex}.perioder.${periodeFieldIndex}.inntektsforhold.${andelFieldIndex}.bruttoInntektPrÅr`,
+      `${formName}.${formFieldIndex}.perioder.${periodeFieldIndex}.inntektsforhold.${andelFieldIndex}.bruttoInntektPrÅr`,
     );
     return {
       aktivitetStatus: andel.aktivitetStatus,
@@ -245,7 +245,7 @@ const TilkommetAktivitetPanel: FC<TilkommetAktivitetPanelType> = ({
         arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
         formName={formName}
         fields={fields}
-        bgIndex={bgIndex}
+        formFieldIndex={formFieldIndex}
         readOnly={readOnly}
         erAksjonspunktÅpent={erAksjonspunktÅpent}
         submittable={submittable}

--- a/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetInntektsforholdField.tsx
+++ b/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetInntektsforholdField.tsx
@@ -17,7 +17,7 @@ import { getAktivitetNavnFraField } from './TilkommetAktivitetUtils';
 
 type TilkommetInntektsforholdFieldType = {
   formName: string;
-  bgIndex: number;
+  formFieldIndex: number;
   periodeFieldIndex: number;
   readOnly: boolean;
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
@@ -41,7 +41,7 @@ export const getInntektsforholdIdentifikator = (inntektsforhold: Inntektsforhold
 
 const TilkommetInntektsforholdField: FC<TilkommetInntektsforholdFieldType> = ({
   formName,
-  bgIndex,
+  formFieldIndex,
   periodeFieldIndex,
   readOnly,
   inntektsforholdFieldIndex,
@@ -51,7 +51,7 @@ const TilkommetInntektsforholdField: FC<TilkommetInntektsforholdFieldType> = ({
   const formMethods = useFormContext<TilkommetAktivitetFormValues>();
   const intl = useIntl();
   const skalRedusereValg = formMethods.watch(
-    `${formName}.${bgIndex}.perioder.${periodeFieldIndex}.inntektsforhold.${inntektsforholdFieldIndex}.skalRedusereUtbetaling`,
+    `${formName}.${formFieldIndex}.perioder.${periodeFieldIndex}.inntektsforhold.${inntektsforholdFieldIndex}.skalRedusereUtbetaling`,
   );
 
   const lagHjelpetekst = (): ReactElement => {
@@ -84,7 +84,7 @@ const TilkommetInntektsforholdField: FC<TilkommetInntektsforholdFieldType> = ({
     <>
       <RadioGroupPanel
         label={getRadioGroupLabel()}
-        name={`${formName}.${bgIndex}.perioder.${periodeFieldIndex}.inntektsforhold.${inntektsforholdFieldIndex}.skalRedusereUtbetaling`}
+        name={`${formName}.${formFieldIndex}.perioder.${periodeFieldIndex}.inntektsforhold.${inntektsforholdFieldIndex}.skalRedusereUtbetaling`}
         radios={[
           { value: 'true', label: intl.formatMessage({ id: 'BeregningInfoPanel.TilkommetAktivitet.Ja' }) },
           { value: 'false', label: intl.formatMessage({ id: 'BeregningInfoPanel.TilkommetAktivitet.Nei' }) },
@@ -113,7 +113,7 @@ const TilkommetInntektsforholdField: FC<TilkommetInntektsforholdFieldType> = ({
           <VerticalSpacer eightPx />
           <div className={styles.bruttoInntektContainer}>
             <InputField
-              name={`${formName}.${bgIndex}.perioder.${periodeFieldIndex}.inntektsforhold.${inntektsforholdFieldIndex}.bruttoInntektPrÅr`}
+              name={`${formName}.${formFieldIndex}.perioder.${periodeFieldIndex}.inntektsforhold.${inntektsforholdFieldIndex}.bruttoInntektPrÅr`}
               label="Fastsett årsinntekt"
               hideLabel
               readOnly={readOnly}


### PR DESCRIPTION
Endrer ındeksen som sendes nedover til å være fieldindexen, som ikke nødvendigvis er samme som beregningsgrunnlagindexen. Når fields opprettes tar man bare med beregningsgrunnlag som har [avklaringsbehovkode VURDER_NYTT_INNTKTSFRHLD](https://github.com/navikt/ft-frontend-saksbehandling/blob/39156454f6f994999be61681830e3991a2e70325/packages/fakta-fordel-beregningsgrunnlag/src/components/tilkommetAktivitet/TilkommetAktivitet.tsx#L104). Det betyr at om  beregningsgrunnlag (bg) 1 i lista ikke har denne koden men bg 2 har det så blir bg 1 filtrert ut og bg 2 blir det første i fields.