### PR TITLE
fikse isValidDate slik at den også avslår 'Invalid date' som NaN

### DIFF
--- a/packages/utils/src/dateUtils.spec.ts
+++ b/packages/utils/src/dateUtils.spec.ts
@@ -6,6 +6,7 @@ import {
   createWeekAndDay,
   dateFormat,
   findDifferenceInMonthsAndDays,
+  isValidDate,
   timeFormat,
 } from './dateUtils';
 
@@ -154,6 +155,25 @@ describe('dateutils', () => {
         months: 2,
         days: 22,
       });
+    });
+  });
+
+  describe('isValidDate', () => {
+    it.each([
+      '12-07-12',
+      '2012-07-12',
+      '2012-07',
+      '2012',
+      '2012-07-12T12:27:34.653Z',
+      '2012.07.12',
+      '2012.07',
+      1342051200000,
+    ])('skal validere gyldig dato %s', date => {
+      expect(isValidDate(date)).toBeTruthy();
+    });
+
+    it.each(['22-07-2012', '2. mai', undefined])('skal validere ugyldig dato %s', date => {
+      expect(isValidDate(date)).toBeFalsy();
     });
   });
 });

--- a/packages/utils/src/dateUtils.ts
+++ b/packages/utils/src/dateUtils.ts
@@ -199,7 +199,7 @@ export function isSameOrBefore(date: string | Dayjs | Date, otherDate: string | 
   return dateInQuestion.isBefore(formattedOtherDate) || dateInQuestion.isSame(formattedOtherDate);
 }
 
-export const isValidDate = (date: any) => !Number.isNaN(new Date(date) as any);
+export const isValidDate = (date: any) => !Number.isNaN(new Date(date).valueOf());
 
 export const getDateAndTime = (tidspunkt?: string): { date: string; time: string } | undefined => {
   if (!tidspunkt) {


### PR DESCRIPTION
Dagens løsning håndterer ugyldige datoer som `'22-07-2012'`, `'2. mai'` eller `undefined` feil.
`isValidDate` returnerer dem som gyldige fordi de er `Invalid Date` og ikke NaN som testen sjekker på. 

`.valueOf()` fikser dette.