### PR TITLE
Legge til prop for å returnere og sette verdien i feltet som Number

### DIFF
--- a/packages/form-hooks/src/NumberField/NumberField.tsx
+++ b/packages/form-hooks/src/NumberField/NumberField.tsx
@@ -19,6 +19,7 @@ export interface Props {
   forceTwoDecimalDigits?: boolean;
   disabled?: boolean;
   className?: string;
+  returnAsNumber?: boolean;
   onChange?: (value: any) => void;
 }
 
@@ -34,6 +35,7 @@ const NumberField = ({
   forceTwoDecimalDigits = false,
   disabled,
   className,
+  returnAsNumber = false,
   onChange,
 }: Props) => {
   const [hasFocus, setFocus] = useState(false);
@@ -88,6 +90,12 @@ const NumberField = ({
         if (onChange) {
           onChange(newValue);
         }
+
+        if (returnAsNumber) {
+          newValue = parseFloat(newValue);
+          if (Number.isNaN(newValue)) newValue = undefined;
+        }
+
         return field.onChange(newValue);
       }}
       onBlur={() => {


### PR DESCRIPTION
Native browser funksjonalitet håndterer input type number som strenger, noe som får strengere typescript til å steile.

Foreslår å legge til en prop som gjør at man får ut verdien som typeriktig Number, istedenfor string. Legger som "opt in" så det ikke vil kunne påvirke eksiterende bruk utilsiktet.