### PR TITLE
Dersom beregningsgrunnlaget blir oppdatert med flere avklaringsbehov …

### DIFF
--- a/packages/prosess-beregningsgrunnlag/src/components/fellesPaneler/AksjonspunktBehandler.tsx
+++ b/packages/prosess-beregningsgrunnlag/src/components/fellesPaneler/AksjonspunktBehandler.tsx
@@ -473,6 +473,10 @@ export const AksjonspunktBehandler = ({
 }: Props) => {
   const intl = useIntl();
 
+  useEffect(() => {
+    setSubmitting(false);
+  }, [beregningsgrunnlagListe[aktivIndex]?.avklaringsbehov.length]);
+
   const losAvklaringsbehov = (values: BeregningFormValues, lp: LovParagraf) => {
     setSubmitting(true);
     submitCallback(transformFields(values, lp));


### PR DESCRIPTION
…må submitknapp låses opp igjen

### Bakgrunn
Har en sak der aksjonspunkt 5039 kommer i en sak etter 5038 er løst. Submitknapp har fortsatt spinner og man får ikke løst 5039.

### Løsning
Låse opp submitknapp dersom man får nye avklaringsbehov