### PR TITLE
fiks avvik-tabell i beregningsgrunnlag

### DIFF
--- a/packages/prosess-beregningsgrunnlag/src/components/fellesPaneler/aksjonspunktBehandler.module.css
+++ b/packages/prosess-beregningsgrunnlag/src/components/fellesPaneler/aksjonspunktBehandler.module.css
@@ -62,50 +62,25 @@
 .verticalAlignMiddle :global(.navds-form-field) {
   gap: initial;
 }
+
 .inntektTableTB {
-  border: 0;
-  border-spacing: 0;
+  --ac-table-row-border: none;
+  --ac-table-row-hover-border: none;
+
+  width: 100%;
 }
-.rowSpacer {
-  height: 14px;
+
+.inntektTableTB > thead > tr > th:not(:last-child),
+.inntektTableTB > tbody > tr > td:not(:last-child),
+.inntektTableTB > tbody > tr > th:not(:last-child) {
+  border-right: 1px solid var(--a-gray-300);
 }
-.inntektTableTB > tbody > tr:first-child > td {
-  border-right: 0;
-  border-top: 0;
-}
-.inntektTableTB > tbody > tr:first-child > td:nth-child(2) {
-  left: 10px;
-}
+
+.inntektTableTB > tbody > tr:last-child > th,
 .inntektTableTB > tbody > tr:last-child > td {
-  border-right: 0;
   border-top: 1px solid var(--a-gray-300);
 }
-.inntektTableTB > tbody > tr > td:first-child {
-  text-align: left;
-}
-.inntektTableTB > tbody > tr:first-child > td:not(:first-child) {
-  padding-left: 20px;
-  text-align: right;
-}
-.inntektTableTB > tbody > tr > td {
-  border-bottom: 0;
-  border-right: 1px solid var(--a-gray-300);
-  padding-bottom: 0;
-  position: relative;
-  text-align: center;
-  top: -1px;
-  vertical-align: middle;
-}
-.inntektTableTB > tbody > tr:not(:first-child) > td:not(:first-child) {
-  padding-left: 20px;
-  padding-right: 20px;
-}
-.inntektTableTB > tbody > tr > td:last-child {
-  border-right: 0;
-}
-.inntektTableTB > thead > tr:first-child > td {
-  border-bottom: 0;
-}
+
 .textAreaWrapper > div > div > label > span > span {
   font-size: inherit;
 }


### PR DESCRIPTION
Før:
<img width="500" alt="Screenshot 2025-03-31 at 14 22 06" src="https://github.com/user-attachments/assets/d23db85e-05b5-46cc-97c4-7ccf49cf5a7a" />
Etter:

<img width="500" alt="Screenshot 2025-03-31 at 14 21 49" src="https://github.com/user-attachments/assets/e25c2f37-065a-4c96-b730-95cf5946d515" />

Hovedforskjellen er:
-  navnet på arbeidsforholdet har colSpan=2, men om det er lite plass vil kolonnen av seg selv bruke mindre plass. 
- mindre space mellom cellene
- aksel-tabell
- header inneholder både dato og "Beregnet År"