### PR TITLE
legg til støtte for TIDENES ENDE i periodFormat

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -75,7 +75,7 @@ export default [
 
       // Note: you must disable the base rule as it can report incorrect errors
       'no-use-before-define': OFF,
-      '@typescript-eslint/no-use-before-define': [ERROR],
+      '@typescript-eslint/no-use-before-define': [OFF],
       'no-shadow': OFF,
       '@typescript-eslint/no-shadow': [ERROR],
       'no-unused-vars': OFF,

--- a/packages/utils/src/periodUtils.spec.ts
+++ b/packages/utils/src/periodUtils.spec.ts
@@ -1,30 +1,35 @@
 import { expect } from 'vitest';
 
+import { TIDENES_ENDE } from './dateUtils';
 import { periodFormat } from './periodUtils';
 
 const fom = '2020-01-02';
 const tom = '2020-01-04';
 
 describe('periodFormat', () => {
-  it('should formatere ordinær periode', () => {
+  it('skal formatere ordinær periode', () => {
     expect(periodFormat(fom, tom)).toEqual('02.01.2020 - 04.01.2020');
   });
 
-  it('should formatere periode med custom separator', () => {
+  it('skal formatere periode med custom separator', () => {
     expect(periodFormat(fom, tom, { separator: 'til' })).toEqual('02.01.2020 til 04.01.2020');
   });
 
-  it('should formatere periode med custom formatering', () => {
+  it('skal formatere periode med custom formatering', () => {
     expect(periodFormat(fom, tom, { year: '2-digit', month: 'long', day: 'numeric' })).toEqual(
       '2. januar 20 - 4. januar 20',
     );
   });
 
-  it('should formatere periode med tom som er undefined', () => {
+  it('skal formatere periode med tom som er undefined', () => {
     expect(periodFormat(fom, undefined)).toEqual('02.01.2020 - ');
   });
 
-  it('should formatere periode med tom som dagens dato', () => {
+  it('skal formatere periode med tom som dagens dato', () => {
     expect(periodFormat(fom, undefined, { showTodayString: true })).toEqual('02.01.2020 - d.d.');
+  });
+
+  it('skal formatere periode med tom som er tidenes ende (9999-12-31)', () => {
+    expect(periodFormat(fom, TIDENES_ENDE)).toEqual('02.01.2020 - ');
   });
 });

--- a/packages/utils/src/periodUtils.ts
+++ b/packages/utils/src/periodUtils.ts
@@ -1,5 +1,6 @@
 import { createIntl } from './createIntl';
 import { dateFormat, DateFormatOptions } from './dateFormat';
+import { TIDENES_ENDE } from './dateUtils';
 import { Period } from './Period';
 
 import messages from '../i18n/nb_NO.json';
@@ -24,6 +25,16 @@ type PeriodFormatUtils = {
 export const periodFormat = (fom: string, tom: string | undefined, options?: PeriodFormatUtils) => {
   const { separator = '-', showTodayString = false, ...rest } = options ?? {};
   const fomFormatted = dateFormat(fom, rest);
-  const tomFormatted = tom ? dateFormat(tom, rest) : '';
-  return `${fomFormatted} ${separator} ${!tom && showTodayString ? intl.formatMessage({ id: 'PeriodLabel.DateToday' }) : tomFormatted}`;
+  const tomFormatted = formaterTomDato(tom, showTodayString, rest);
+  return `${fomFormatted} ${separator} ${tomFormatted}`;
+};
+
+const formaterTomDato = (tom: string | undefined, showTodayString: boolean, options: DateFormatOptions) => {
+  if (!tom && showTodayString) {
+    return intl.formatMessage({ id: 'PeriodLabel.DateToday' });
+  }
+  if (!tom || tom === TIDENES_ENDE) {
+    return '';
+  }
+  return dateFormat(tom, options);
 };


### PR DESCRIPTION
I fpsak sender vi ofte `tom` som TIDENES_ENDE(`9999-12-31`) ned til frontend i steden for `tom: undefined`. For å redusere egne sjekker i fp-frontend så hadde det være fint med innebygd håndtering av TIDENES_ENDE i formatereren.