### PR TITLE
fjern bodyShort-wrapper i PeriodLabel

### DIFF
--- a/packages/fakta-beregning/src/components/avklareAktiviteter/VurderAktiviteterRow.tsx
+++ b/packages/fakta-beregning/src/components/avklareAktiviteter/VurderAktiviteterRow.tsx
@@ -82,8 +82,8 @@ export const VurderAktiviteterTabellRad = ({
       </Table.DataCell>
       <Table.DataCell className={styles.rowalign}>
         {!erOverstyrt && (
-          <BodyShort>
-            <PeriodLabel size="small" dateStringFom={aktivitet.fom} dateStringTom={aktivitet.tom} />
+          <BodyShort size="small">
+            <PeriodLabel dateStringFom={aktivitet.fom} dateStringTom={aktivitet.tom} />
           </BodyShort>
         )}
         {erOverstyrt && (

--- a/packages/fakta-beregning/src/components/fellesFaktaForATFLogSN/InntektFieldArrayRow.tsx
+++ b/packages/fakta-beregning/src/components/fellesFaktaForATFLogSN/InntektFieldArrayRow.tsx
@@ -157,13 +157,8 @@ export const InntektFieldArrayAndelRow = ({
       <Table.DataCell>
         {skalVisePeriode && harPeriode && field.arbeidsperiodeFom && (
           <ReadOnlyField
-            value={
-              <PeriodLabel
-                size="small"
-                dateStringFom={field.arbeidsperiodeFom}
-                dateStringTom={field.arbeidsperiodeTom}
-              />
-            }
+            size="small"
+            value={<PeriodLabel dateStringFom={field.arbeidsperiodeFom} dateStringTom={field.arbeidsperiodeTom} />}
           />
         )}
       </Table.DataCell>

--- a/packages/ui-komponenter/src/PeriodLabel.tsx
+++ b/packages/ui-komponenter/src/PeriodLabel.tsx
@@ -1,12 +1,9 @@
-import { BodyShort } from '@navikt/ds-react';
-
 import { periodFormat } from '@navikt/ft-utils';
 
 export interface Props {
   dateStringFom: string;
   dateStringTom?: string;
   showTodayString?: boolean;
-  size?: 'medium' | 'small';
 }
 
 /**
@@ -19,8 +16,6 @@ export interface Props {
  * <PeriodLabel dateStringFom="2017-08-25" dateStringTom="2017-08-31" />
  * ```
  */
-export const PeriodLabel = ({ dateStringFom, dateStringTom, showTodayString = false, size }: Props) => (
-  <BodyShort as="span" size={size}>
-    {periodFormat(dateStringFom, dateStringTom, { showTodayString })}
-  </BodyShort>
+export const PeriodLabel = ({ dateStringFom, dateStringTom, showTodayString = false }: Props) => (
+  <>{periodFormat(dateStringFom, dateStringTom, { showTodayString })}</>
 );


### PR DESCRIPTION
Jeg så i koden til k9 og de har bare ett tilfelle av PeriodLabel, og den wrappes i BodyShort, så denne endringen vil ikke påvirke dem.