### PR TITLE
fiks size prop og sorter neon av props til form hooks

### DIFF
--- a/packages/form-hooks/src/RhfCheckbox/RhfCheckbox.tsx
+++ b/packages/form-hooks/src/RhfCheckbox/RhfCheckbox.tsx
@@ -13,6 +13,7 @@ type Props<T extends FieldValues> = {
   onClick?: () => void;
   className?: string;
   control: UseControllerProps<T>['control'];
+  size?: 'medium' | 'small';
 } & Omit<UseControllerProps<T>, 'control'>;
 
 export const RhfCheckbox = <T extends FieldValues>({
@@ -22,6 +23,7 @@ export const RhfCheckbox = <T extends FieldValues>({
   onChange,
   onClick,
   className,
+  size = 'small',
   ...controllerProps
 }: Props<T>) => {
   const { name, control, disabled } = controllerProps;
@@ -43,7 +45,7 @@ export const RhfCheckbox = <T extends FieldValues>({
   return (
     <>
       <Checkbox
-        size="small"
+        size={size}
         disabled={disabled || readOnly}
         checked={field.value === true}
         className={className}

--- a/packages/form-hooks/src/RhfDatepicker/RhfDatepicker.tsx
+++ b/packages/form-hooks/src/RhfDatepicker/RhfDatepicker.tsx
@@ -16,13 +16,13 @@ type Props<T extends FieldValues> = {
   label?: string | ReactNode;
   hideLabel?: boolean;
   description?: string | ReactNode;
-  validate?: ((value: string) => ValidationReturnType)[];
+  size?: 'medium' | 'small';
   isReadOnly?: boolean;
   onChange?: (value: any) => void;
   disabledDays?: DatePickerProps['disabled'];
   isEdited?: boolean;
+  validate?: ((value: string) => ValidationReturnType)[];
   defaultMonth?: Date;
-  size?: 'medium' | 'small';
   fromDate?: Date;
   toDate?: Date;
   control: UseControllerProps<T>['control'];
@@ -34,13 +34,13 @@ export const RhfDatepicker = <T extends FieldValues>({
   validate = [],
   hideLabel = false,
   isReadOnly = false,
+  size = 'small',
   onChange,
   disabledDays,
   isEdited,
   defaultMonth,
   fromDate,
   toDate,
-  size = 'small',
   ...controllerProps
 }: Props<T>) => {
   const { name, control, disabled } = controllerProps;

--- a/packages/form-hooks/src/RhfNumericField/RhfNumericField.tsx
+++ b/packages/form-hooks/src/RhfNumericField/RhfNumericField.tsx
@@ -10,6 +10,7 @@ const TWO_DECIMALS_REGEXP = /^(\d+[,]?(\d{1,2})?)$/;
 const DECIMAL_REGEXP = /^(\d{1,20}[,.]?(\d{1,10})?)$/;
 
 type Props<T extends FieldValues> = {
+  size?: 'medium' | 'small';
   label?: string | ReactNode;
   hideLabel?: boolean;
   validate?: ((value: string) => ValidationReturnType)[] | ((value: number) => ValidationReturnType)[];
@@ -36,6 +37,7 @@ export const RhfNumericField = <T extends FieldValues>({
   className,
   returnAsNumber = false,
   onChange,
+  size = 'small',
   ...controllerProps
 }: Props<T>) => {
   const { name, control, disabled } = controllerProps;
@@ -65,7 +67,7 @@ export const RhfNumericField = <T extends FieldValues>({
 
   return (
     <TextField
-      size="small"
+      size={size}
       description={description}
       label={label}
       error={getError(errors, name)}

--- a/packages/form-hooks/src/RhfRadioGroup/RhfRadioGroup.tsx
+++ b/packages/form-hooks/src/RhfRadioGroup/RhfRadioGroup.tsx
@@ -15,18 +15,18 @@ export interface RadioProps {
 }
 
 type Props<T extends FieldValues> = {
-  description?: string;
   label?: string | ReactNode;
+  description?: string;
+  hideLegend?: boolean;
+  isHorizontal?: boolean;
+  isTrueOrFalseSelection?: boolean;
+  isReadOnly?: boolean;
+  isEdited?: boolean;
+  size?: 'medium' | 'small';
   radios: RadioProps[];
   validate?: ((value: string | number) => ValidationReturnType)[];
   onChange?: (value: any) => void;
-  isReadOnly?: boolean;
-  isHorizontal?: boolean;
   parse?: (value: string) => any;
-  isTrueOrFalseSelection?: boolean;
-  hideLegend?: boolean;
-  isEdited?: boolean;
-  size?: 'medium' | 'small';
   control: UseControllerProps<T>['control'];
 } & Omit<UseControllerProps<T>, 'control'>;
 

--- a/packages/form-hooks/src/RhfRadioGroup/RhfRadioGroupNew.tsx
+++ b/packages/form-hooks/src/RhfRadioGroup/RhfRadioGroupNew.tsx
@@ -10,14 +10,14 @@ import { getError, getValidationRules, type ValidationReturnType } from '../form
 type Props<T extends FieldValues> = {
   description?: string | ReactNode;
   label?: string | ReactNode;
+  size?: 'medium' | 'small';
+  isReadOnly?: boolean;
+  isEdited?: boolean;
+  hideLegend?: boolean;
   validate?: Array<(value: string | number | boolean) => ValidationReturnType>;
   onChange?: (value: string | boolean | number) => void;
   children: ReactElement | ReactElement[];
   className?: string;
-  isReadOnly?: boolean;
-  size?: 'medium' | 'small';
-  isEdited?: boolean;
-  hideLegend?: boolean;
   control: UseControllerProps<T>['control'];
 } & Omit<UseControllerProps<T>, 'control'>;
 

--- a/packages/form-hooks/src/RhfRangepicker/RhfRangepicker.tsx
+++ b/packages/form-hooks/src/RhfRangepicker/RhfRangepicker.tsx
@@ -23,6 +23,7 @@ interface Props {
   fromDate?: Date;
   toDate?: Date;
   isEdited?: boolean;
+  size?: 'medium' | 'small';
 }
 
 // @deprecated brukes ikke(?)

--- a/packages/form-hooks/src/RhfSelect/RhfSelect.tsx
+++ b/packages/form-hooks/src/RhfSelect/RhfSelect.tsx
@@ -8,16 +8,16 @@ import { ReadOnlyField } from '../ReadOnlyField/ReadOnlyField';
 
 type Props<T extends FieldValues> = {
   label: string | ReactNode;
+  size?: 'medium' | 'small';
+  description?: ReactNode;
+  hideLabel?: boolean;
+  readOnly?: boolean;
+  isEdited?: boolean;
   onChange?: (event: any) => void;
   validate?: ((value: string) => ValidationReturnType)[];
-  readOnly?: boolean;
   selectValues: React.ReactElement<any>[];
-  description?: ReactNode;
   hideValueOnDisable?: boolean;
   className?: string;
-  hideLabel?: boolean;
-  isEdited?: boolean;
-  size?: 'medium' | 'small';
   control: UseControllerProps<T>['control'];
 } & Omit<UseControllerProps<T>, 'control'>;
 
@@ -32,7 +32,7 @@ export const RhfSelect = <T extends FieldValues>({
   className,
   hideLabel,
   isEdited,
-  size,
+  size = 'small',
   ...controllerProps
 }: Props<T>) => {
   const { name, control, disabled } = controllerProps;
@@ -64,7 +64,7 @@ export const RhfSelect = <T extends FieldValues>({
 
   return (
     <Select
-      size="small"
+      size={size}
       className={className}
       error={getError(errors, name)}
       label={label}

--- a/packages/form-hooks/src/RhfTextField/RhfTextField.tsx
+++ b/packages/form-hooks/src/RhfTextField/RhfTextField.tsx
@@ -9,8 +9,15 @@ import { ReadOnlyField } from '../ReadOnlyField/ReadOnlyField';
 type Props<T extends FieldValues> = {
   name: string;
   label?: string | ReactNode;
-  validate?: ((value: string) => ValidationReturnType)[] | ((value: number) => ValidationReturnType)[];
   readOnly?: boolean;
+  disabled?: boolean;
+  type?: 'email' | 'password' | 'tel' | 'text' | 'url';
+  isEdited?: boolean;
+  maxLength?: number;
+  autoComplete?: boolean;
+  className?: string;
+  hideLabel?: boolean;
+  validate?: ((value: string) => ValidationReturnType)[] | ((value: number) => ValidationReturnType)[];
   onBlur?: (value: any) => void;
   onChange?: (value: any) => void;
   shouldValidateOnBlur?: boolean;
@@ -18,13 +25,6 @@ type Props<T extends FieldValues> = {
   parse?: (value: string | number) => string | number;
   format?: (value: string) => string;
   normalizeOnBlur?: (value: string | number) => string | number;
-  isEdited?: boolean;
-  maxLength?: number;
-  autoComplete?: boolean;
-  disabled?: boolean;
-  type?: 'email' | 'password' | 'tel' | 'text' | 'url';
-  className?: string;
-  hideLabel?: boolean;
   control: UseControllerProps<T>['control'];
 } & Omit<TextFieldProps, 'label' | 'autoComplete'> &
   Omit<UseControllerProps<T>, 'control'>;
@@ -50,6 +50,7 @@ export const RhfTextField = <T extends FieldValues>({
   disabled,
   className,
   hideLabel,
+  size = 'small',
   ...props
 }: Props<T>) => {
   const {
@@ -66,14 +67,12 @@ export const RhfTextField = <T extends FieldValues>({
   });
 
   if (readOnly) {
-    return (
-      <ReadOnlyField label={label} value={field.value} isEdited={isEdited} hideLabel={hideLabel} size={props.size} />
-    );
+    return <ReadOnlyField label={label} value={field.value} isEdited={isEdited} hideLabel={hideLabel} size={size} />;
   }
 
   return (
     <TextField
-      size="small"
+      size={size}
       hideLabel={hideLabel}
       description={description}
       label={label}

--- a/packages/form-hooks/src/RhfTextarea/RhfTextarea.tsx
+++ b/packages/form-hooks/src/RhfTextarea/RhfTextarea.tsx
@@ -18,14 +18,14 @@ interface Badges {
 type Props<T extends FieldValues> = {
   label: string | ReactNode;
   readOnly?: boolean;
+  size?: 'small' | 'medium';
+  description?: string;
   maxLength?: number;
   badges?: Badges[];
   validate?: ((value: string) => ValidationReturnType)[];
   parse?: (value: string | number) => string | number;
   className?: string;
-  description?: string;
   isEdited?: boolean;
-  size?: 'small' | 'medium';
   control: UseControllerProps<T>['control'];
 } & TextareaProps &
   Omit<UseControllerProps<T>, 'control'>;


### PR DESCRIPTION
grunnen til at jeg har endret litt på rekkefølgen til props er fordi det bestemmer rekkefølgen på  controls i storybook. Se bilde
<img width="603" height="734" alt="Screenshot 2025-08-20 at 10 35 11" src="https://github.com/user-attachments/assets/8c3a4b32-6591-40f7-ac7d-be5a452f459f" />

Grunnen til utbedringen av size begynte med denne størrelse forskjellen på felter i readonly modus i fp-sak
<img width="603" height="380" alt="Screenshot 2025-08-20 at 10 35 27" src="https://github.com/user-attachments/assets/e8fc8b82-e92b-4b88-807e-055074a9833f" />
