### PR TITLE
ny visning for RhfRadioGroup i readonly mode

### DIFF
--- a/packages/fakta-beregning/src/BeregningFaktaIndex.spec.tsx
+++ b/packages/fakta-beregning/src/BeregningFaktaIndex.spec.tsx
@@ -63,7 +63,7 @@ describe('BeregningFaktaIndex', () => {
 
     // Bytter tab
     await userEvent.click(screen.getByRole('tab', { name: '13.02.2022 - 20.02.2022' }));
-    expect(screen.getAllByRole('radio')[0]).toBeDisabled();
+    expect(screen.getAllByRole('group')[0]).toHaveAttribute('aria-readonly', 'true');
     await userEvent.click(screen.getAllByTestId('overstyringsknapp')[0]);
     await userEvent.type(screen.getAllByLabelText('Begrunnelse')[0], 'Test');
     await userEvent.click(screen.getByRole('button', { name: 'Overstyr' }));
@@ -92,7 +92,7 @@ describe('BeregningFaktaIndex', () => {
   it('skal vise read only dersom ikke overstyrer men har overstyringsaksjonspunkt', () => {
     render(<VisningAvOverstyrtAvklarAktiviteterUtenOverstyringsrettighet />);
     expect(screen.getAllByTestId('overstyringsknapp')[0]).toHaveAttribute('aria-disabled', 'true');
-    expect(screen.getAllByRole('radio')[0]).toBeDisabled();
+    expect(screen.getAllByRole('group')[0]).toHaveAttribute('aria-readonly', 'true');
   });
 
   it('skal ikke vise redigertikon dersom arbeid og AAP med utført aksjonspunkt', () => {
@@ -201,8 +201,9 @@ describe('BeregningFaktaIndex', () => {
   it('skal håndtere at aktiviteter i beregning er overstyrt og SB ikke er overstyrer', () => {
     render(<VisningAvOverstyrtAvklarAktiviteterUtenOverstyringsrettighet />);
     expect(screen.queryByTestId('overstyringsknapp')).toHaveAttribute('aria-disabled', 'true');
-    expect(screen.getAllByRole('radio')[0]).toBeDisabled();
-    expect(screen.getAllByRole('radio')[2]).toBeDisabled();
+    const radioGruppe = screen.getAllByRole('group');
+    expect(radioGruppe[0]).toHaveAttribute('aria-readonly', 'true');
+    expect(radioGruppe[1]).toHaveAttribute('aria-readonly', 'true');
   });
 
   it('skal kunne fastsette inntekt for arbeidstaker og frilanser i samme organisasjon', async () => {

--- a/packages/form-hooks/src/RhfRadioGroup/RhfRadioGroup.spec.tsx
+++ b/packages/form-hooks/src/RhfRadioGroup/RhfRadioGroup.spec.tsx
@@ -5,7 +5,7 @@ import { expect } from 'vitest';
 
 import * as stories from './RhfRadioGroup.stories';
 
-const { Default } = composeStories(stories);
+const { Default, ReadOnlyMedOverstyrtMarkering } = composeStories(stories);
 
 describe('RhfRadioGroup', () => {
   it('skal sette verdi', async () => {
@@ -21,5 +21,13 @@ describe('RhfRadioGroup', () => {
 
     await userEvent.click(screen.getByText('Ikke oppfylt'));
     expect(screen.getByLabelText('Ikke oppfylt')).toBeChecked();
+  });
+
+  it('skal vise readonly verdier', async () => {
+    await ReadOnlyMedOverstyrtMarkering.run();
+    expect(screen.getByRole('group')).toHaveAttribute('aria-readonly', 'true');
+    expect(screen.getByLabelText('Oppfylt')).not.toBeChecked();
+    await userEvent.click(screen.getByText('Oppfylt'));
+    expect(screen.getByLabelText('Oppfylt')).not.toBeChecked();
   });
 });

--- a/packages/form-hooks/src/RhfRadioGroup/RhfRadioGroup.tsx
+++ b/packages/form-hooks/src/RhfRadioGroup/RhfRadioGroup.tsx
@@ -2,10 +2,13 @@ import { type ReactElement, type ReactNode } from 'react';
 import { type FieldValues, useController, type UseControllerProps, useFormContext } from 'react-hook-form';
 
 import { HStack, RadioGroup } from '@navikt/ds-react';
+import classnames from 'classnames';
 
 import { EditedIcon } from '@navikt/ft-ui-komponenter';
 
 import { getError, getValidationRules, type ValidationReturnType } from '../formUtils';
+
+import styles from './rhfRadioGroup.module.css';
 
 type Props<T extends FieldValues> = {
   description?: string | ReactNode;
@@ -35,7 +38,6 @@ export const RhfRadioGroup = <T extends FieldValues>({
   ...controllerProps
 }: Props<T>) => {
   const { name, control } = controllerProps;
-
   const {
     formState: { errors },
   } = useFormContext();
@@ -58,7 +60,8 @@ export const RhfRadioGroup = <T extends FieldValues>({
         </HStack>
       }
       hideLegend={hideLegend}
-      disabled={isReadOnly}
+      aria-readonly={isReadOnly}
+      readOnly={isReadOnly}
       description={description}
       size={size}
       error={getError(errors, name)}
@@ -68,7 +71,7 @@ export const RhfRadioGroup = <T extends FieldValues>({
         }
         field.onChange(value);
       }}
-      className={className}
+      className={classnames(className, styles.noReadOnlyIcon)}
     >
       {children}
     </RadioGroup>

--- a/packages/form-hooks/src/RhfRadioGroup/rhfRadioGroup.module.css
+++ b/packages/form-hooks/src/RhfRadioGroup/rhfRadioGroup.module.css
@@ -1,0 +1,6 @@
+
+.noReadOnlyIcon {
+    legend > svg {
+        display: none;
+    }
+}


### PR DESCRIPTION
**Gammel visning:**

> <img width="421" height="213" alt="Screenshot 2025-09-11 at 14 30 16" src="https://github.com/user-attachments/assets/6a79e806-6870-4073-8261-62e91c555f6f" />


**Default readonly-stil fra aksel:**

> <img width="442" height="213" alt="Screenshot 2025-09-11 at 14 29 32" src="https://github.com/user-attachments/assets/02fd48fc-3c24-4c11-a1aa-93d6324fd078" />

**Mitt forslag: Readonly stil fra aksel uten lås-ikon:**

> <img width="421" height="213" alt="Screenshot 2025-09-11 at 14 29 47" src="https://github.com/user-attachments/assets/a028260c-709d-4504-b901-90c2c24c2b99" />