### PR TITLE
Forbedre RhfNumericField og valideringslogikk

### DIFF
--- a/packages/form-hooks/.storybook/decorators.tsx
+++ b/packages/form-hooks/.storybook/decorators.tsx
@@ -19,8 +19,10 @@ export const rhfDecorator =
       control: formMethods.control,
     };
 
+    const onSubmit = (context.parameters?.['onSubmit'] ?? action('submit')) as (data: unknown) => Promise<unknown>;
+
     return (
-      <RhfForm formMethods={formMethods} onSubmit={action('submit') as (data: unknown) => Promise<unknown>}>
+      <RhfForm formMethods={formMethods} onSubmit={onSubmit}>
         <VStack gap="space-16">
           <Story />
           <div>

--- a/packages/form-hooks/package.json
+++ b/packages/form-hooks/package.json
@@ -36,6 +36,7 @@
     "@navikt/ft-config-eslint": "workspace:^",
     "@navikt/ft-config-typescript": "workspace:^",
     "@navikt/ft-config-vite": "workspace:^",
+    "@navikt/ft-form-validators": "workspace:^",
     "@navikt/ft-ui-komponenter": "workspace:^",
     "@navikt/ft-utils": "workspace:^",
     "@testing-library/dom": "10.4.1",

--- a/packages/form-hooks/src/RhfNumericField/RhfNumericField.spec.tsx
+++ b/packages/form-hooks/src/RhfNumericField/RhfNumericField.spec.tsx
@@ -5,14 +5,140 @@ import { expect } from 'vitest';
 
 import * as stories from './RhfNumericField.stories';
 
-export const { Default } = composeStories(stories);
+const {
+  Default,
+  ReadOnly,
+  Høyrestilt,
+  Deaktivert,
+  OrganisasjonsnummerMedValidering,
+  BeløpMedDesimalValidering,
+  BeløpMedHeltallValidering,
+} = composeStories(stories);
 
 describe('RhfNumericField', () => {
-  it('skal sette verdi', async () => {
+  it('skal vise label og starte med tomt felt', async () => {
     await Default.run();
     expect(screen.getByText('Dette er et numberfelt')).toBeInTheDocument();
-    expect(screen.getByLabelText('Dette er et numberfelt')).toHaveValue('');
-    await userEvent.type(screen.getByLabelText('Dette er et numberfelt'), '27,667');
-    expect(screen.getByLabelText('Dette er et numberfelt')).toHaveValue('27,66');
+    expect(screen.getByLabelText('Dette er et numberfelt')).toHaveValue(null);
+  });
+
+  it('skal akseptere heltall', async () => {
+    await Default.run();
+    await userEvent.type(screen.getByLabelText('Dette er et numberfelt'), '42');
+    expect(screen.getByLabelText('Dette er et numberfelt')).toHaveValue(42);
+  });
+
+  it('skal akseptere desimaltall', async () => {
+    await Default.run();
+    await userEvent.type(screen.getByLabelText('Dette er et numberfelt'), '12.5');
+    expect(screen.getByLabelText('Dette er et numberfelt')).toHaveValue(12.5);
+  });
+
+  it('skal avvise bokstaver og spesialtegn', async () => {
+    await Default.run();
+    const input = screen.getByLabelText('Dette er et numberfelt');
+    await userEvent.type(input, 'abc!@#');
+    expect(input).toHaveValue(null);
+  });
+
+  it('skal vise forhåndsutfylt verdi', async () => {
+    await Høyrestilt.run();
+    expect(screen.getByLabelText('Høyrestilt tall')).toHaveValue(45.1);
+  });
+
+  it('skal vise readonly-verdi som tekst og ikke som inputfelt', async () => {
+    await ReadOnly.run();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.getByText('45.1')).toBeInTheDocument();
+  });
+
+  it('skal vise deaktivert inputfelt', async () => {
+    await Deaktivert.run();
+    expect(screen.getByLabelText('Deaktivert tallfelt')).toBeDisabled();
+  });
+
+  it('skal vise valideringsfeil ved innsending uten verdi', async () => {
+    await BeløpMedHeltallValidering.run();
+
+    await userEvent.clear(screen.getByLabelText('Beløp'));
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByText('Feltet må fylles ut')).toBeInTheDocument();
+  });
+
+  it('skal ikke vise valideringsfeil når feltet er fylt ut', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    await BeløpMedHeltallValidering.run({ parameters: { onSubmit } });
+    await userEvent.type(screen.getByLabelText('Beløp'), '5');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ tomtfelt: 5 }));
+  });
+
+  it('skal gi valideringsfeil for ugyldig organisasjonsnummer', async () => {
+    await OrganisasjonsnummerMedValidering.run();
+    await userEvent.type(screen.getByLabelText('Organisasjonsnummer'), '123');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(
+      await screen.findByText('Ugyldig organisasjonsnummer. Organisasjonsnummer må være 9 siffer.'),
+    ).toBeInTheDocument();
+  });
+
+  it('skal sende inn gyldig organisasjonsnummer som tall ved submit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    await OrganisasjonsnummerMedValidering.run({ parameters: { onSubmit } });
+    await userEvent.type(screen.getByLabelText('Organisasjonsnummer'), '123456789');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ tomtfelt: 123456789 }));
+  });
+
+  it('skal gi valideringsfeil for beløp med for mange desimaler', async () => {
+    await BeløpMedDesimalValidering.run();
+    await userEvent.type(screen.getByLabelText('Beløp'), '12.567');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByText('Tallet kan ikke inneholde mer enn to desimaler')).toBeInTheDocument();
+  });
+
+  it('skal sende inn beløp med to desimaler som tall ved submit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    await BeløpMedDesimalValidering.run({ parameters: { onSubmit } });
+    await userEvent.type(screen.getByLabelText('Beløp'), '12.56');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ tomtfelt: 12.56 }));
+  });
+
+  it('skal sende inn negativt beløp som tall ved submit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    await BeløpMedHeltallValidering.run({ parameters: { onSubmit } });
+    await userEvent.type(screen.getByLabelText('Beløp'), '-42');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ tomtfelt: -42 }));
+  });
+
+  it('skal gi valideringsfeil for beløp uten desimaler når desimal skrives inn', async () => {
+    await BeløpMedHeltallValidering.run();
+    await userEvent.type(screen.getByLabelText('Beløp'), '12.5');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByText('Tallet kan ikke ha desimaler')).toBeInTheDocument();
+  });
+
+  it('skal sende inn heltall uten desimaler som tall ved submit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    await BeløpMedHeltallValidering.run({ parameters: { onSubmit } });
+    await userEvent.type(screen.getByLabelText('Beløp'), '100');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ tomtfelt: 100 }));
+  });
+
+  it('skal lime inn desimaltall', async () => {
+    await BeløpMedHeltallValidering.run();
+    await userEvent.click(screen.getByLabelText('Beløp'));
+    await userEvent.paste('150 000.56');
+    expect(screen.getByLabelText('Beløp')).toHaveValue(150000.56);
+  });
+
+  it('skal lime inn negativt tall', async () => {
+    await BeløpMedHeltallValidering.run();
+    await userEvent.click(screen.getByLabelText('Beløp'));
+    await userEvent.paste('−96 164');
+    expect(screen.getByLabelText('Beløp')).toHaveValue(-96164);
   });
 });

--- a/packages/form-hooks/src/RhfNumericField/RhfNumericField.stories.tsx
+++ b/packages/form-hooks/src/RhfNumericField/RhfNumericField.stories.tsx
@@ -1,12 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import { hasValidDecimal, hasValidOrgNumber, hasValidPosOrNegInteger, required } from '@navikt/ft-form-validators';
+
 import { rhfDecorator } from '../../.storybook/decorators';
 import { RhfNumericField } from './RhfNumericField';
 
 const meta = {
   component: RhfNumericField,
   tags: ['autodocs'],
-  decorators: rhfDecorator({ testnumberpre: 45.1 }),
+  decorators: rhfDecorator({ verdi: 45.1 }),
   args: {
     control: undefined, // This will be provided by the decorator
   },
@@ -19,22 +21,58 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     label: 'Dette er et numberfelt',
-    name: 'testnumber',
-    forceTwoDecimalDigits: true,
+    name: 'tomtfelt',
   },
 };
 
-export const MedVerdi: Story = {
+export const Høyrestilt: Story = {
   args: {
-    label: 'Dette er et numberfelt der verdi er valgt',
-    name: 'testnumberpre',
+    label: 'Høyrestilt tall',
+    name: 'verdi',
+    align: 'right',
+    htmlSize: 10,
   },
 };
 
 export const ReadOnly: Story = {
   args: {
     label: 'Dette er et numberfelt som er readonly',
-    name: 'testnumberpre',
+    name: 'verdi',
     readOnly: true,
+  },
+};
+
+export const Deaktivert: Story = {
+  args: {
+    label: 'Deaktivert tallfelt',
+    name: 'verdi',
+    disabled: true,
+  },
+};
+
+export const OrganisasjonsnummerMedValidering: Story = {
+  args: {
+    label: 'Organisasjonsnummer',
+    description: 'Må være et gyldig organisasjonsnummer på 9 karakterer som er positivt',
+    name: 'tomtfelt',
+    validate: [required, hasValidOrgNumber],
+  },
+};
+
+export const BeløpMedHeltallValidering: Story = {
+  args: {
+    label: 'Beløp',
+    description: 'Må være positivt eller negativt heltall',
+    name: 'tomtfelt',
+    validate: [required, hasValidPosOrNegInteger],
+  },
+};
+
+export const BeløpMedDesimalValidering: Story = {
+  args: {
+    label: 'Beløp',
+    description: 'Må være positivt med maksimalt to desimaler',
+    name: 'tomtfelt',
+    validate: [required, hasValidDecimal],
   },
 };

--- a/packages/form-hooks/src/RhfNumericField/RhfNumericField.tsx
+++ b/packages/form-hooks/src/RhfNumericField/RhfNumericField.tsx
@@ -1,24 +1,24 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { type FieldValues, useController, type UseControllerProps, useFormContext } from 'react-hook-form';
 
 import { TextField, type TextFieldProps } from '@navikt/ds-react';
 
+import { sanitizeNumericString } from '@navikt/ft-utils';
+
 import { getError, getValidationRules, type ValidationReturnType } from '../formUtils';
 import { ReadOnlyField } from '../ReadOnlyField/ReadOnlyField';
 
-const TWO_DECIMALS_REGEXP = /^(\d+[,]?(\d{1,2})?)$/;
-const DECIMAL_REGEXP = /^(\d{1,20}[,.]?(\d{1,10})?)$/;
+import styles from './rhfNumericField.module.css';
 
 type Props<T extends FieldValues> = {
-  validate?: ((value: string) => ValidationReturnType)[] | ((value: number) => ValidationReturnType)[];
-  autoFocus?: boolean;
+  validate?: ((value: any) => ValidationReturnType)[];
   isEdited?: boolean;
-  forceTwoDecimalDigits?: boolean;
-  returnAsNumber?: boolean;
-  onChange?: (value: any) => void;
+  onChange?: (value: string) => void;
+  onBlur?: (value: string) => void;
+  align?: 'left' | 'right';
   control: UseControllerProps<T>['control'];
 } & Omit<UseControllerProps<T>, 'control'> &
-  Omit<TextFieldProps, 'value' | 'defaultValue' | 'type' | 'inputMode' | 'onChange'>;
+  Omit<TextFieldProps, 'value' | 'defaultValue' | 'type' | 'inputMode'>;
 
 export const RhfNumericField = <T extends FieldValues>({
   label,
@@ -27,21 +27,21 @@ export const RhfNumericField = <T extends FieldValues>({
   readOnly,
   description,
   isEdited,
-  forceTwoDecimalDigits = false,
-  returnAsNumber = false,
   onChange,
-  autoComplete = 'off',
+  onBlur,
   size = 'small',
+  align,
   name,
   control,
   disabled,
+  autoFocus,
+  maxLength,
   ...rest
 }: Props<T>) => {
-  const [hasFocus, setHasFocus] = useState(false);
-
   const {
     formState: { errors },
   } = useFormContext();
+
   const { field } = useController({
     name,
     control,
@@ -51,57 +51,51 @@ export const RhfNumericField = <T extends FieldValues>({
   });
 
   if (readOnly) {
-    return <ReadOnlyField label={label} value={field.value} isEdited={isEdited} hideLabel={hideLabel} size={size} />;
+    return (
+      <ReadOnlyField
+        align={align}
+        label={label}
+        value={field.value}
+        isEdited={isEdited}
+        hideLabel={hideLabel}
+        size={size}
+      />
+    );
   }
-
-  const regex = forceTwoDecimalDigits ? TWO_DECIMALS_REGEXP : DECIMAL_REGEXP;
-
-  const value = field.value !== undefined && field.value !== null ? field.value.toString() : '';
-  const formattedValue =
-    !hasFocus && forceTwoDecimalDigits && value !== '' && !Number.isNaN(value) ? parseFloat(value).toFixed(2) : value;
 
   return (
     <TextField
-      size={size}
-      description={description}
       label={label}
-      error={getError(errors, name)}
-      {...field}
-      value={formattedValue.replace('.', ',')}
-      autoComplete={autoComplete}
-      disabled={disabled}
-      type="text"
-      hideLabel={hideLabel}
+      description={description}
+      type="number"
       inputMode="decimal"
-      onChange={event => {
-        setHasFocus(true);
-        const targetValue = event.currentTarget.value;
-        let newValue;
-        if (targetValue === '') {
-          newValue = null;
-        } else if (regex.test(targetValue)) {
-          newValue = targetValue.replace(',', '.');
-        } else {
-          newValue = field.value;
-        }
-
-        if (onChange) {
-          onChange(newValue);
-        }
-
-        if (newValue && returnAsNumber) {
-          newValue = parseFloat(newValue);
-          if (Number.isNaN(newValue)) newValue = null;
-        }
-
-        return field.onChange(newValue);
-      }}
-      onBlur={() => {
-        setHasFocus(false);
+      error={getError(errors, name)}
+      autoFocus={autoFocus}
+      autoComplete="off"
+      maxLength={maxLength}
+      disabled={disabled}
+      size={size}
+      className={align === 'right' ? styles.alignRight : undefined}
+      {...field}
+      value={field.value ?? ''}
+      onBlur={event => {
         field.onBlur();
-
-        if (forceTwoDecimalDigits && value.slice(-1) === '.') {
-          field.onChange(value + 0);
+        onBlur?.(event.currentTarget.value);
+      }}
+      onChange={event => {
+        const raw = event.currentTarget.value;
+        const value = raw === '' ? null : Number(raw);
+        field.onChange(Number.isNaN(value) ? null : value);
+        onChange?.(raw);
+      }}
+      onPaste={event => {
+        const text = event.clipboardData.getData('text');
+        const normalized = sanitizeNumericString(text);
+        const num = normalized === '' ? null : Number(normalized);
+        if (num === null || !Number.isNaN(num)) {
+          event.preventDefault();
+          field.onChange(num);
+          onChange?.(normalized);
         }
       }}
       {...rest}

--- a/packages/form-hooks/src/RhfNumericField/rhfNumericField.module.css
+++ b/packages/form-hooks/src/RhfNumericField/rhfNumericField.module.css
@@ -1,0 +1,5 @@
+.alignRight {
+  input {
+    text-align: right;
+  }
+}

--- a/packages/form-validators/src/validators.spec.ts
+++ b/packages/form-validators/src/validators.spec.ts
@@ -519,5 +519,15 @@ describe('Validators', () => {
       const result = hasValidOrgNumber(undefined as unknown as string);
       expect(result).toEqual('Ugyldig organisasjonsnummer. Organisasjonsnummer må være 9 siffer.');
     });
+
+    it('skal feile når organisasjonsnummer er negativt tall', () => {
+      const result = hasValidOrgNumber(-12345678);
+      expect(result).toEqual('Ugyldig organisasjonsnummer. Organisasjonsnummer må være 9 siffer.');
+    });
+
+    it('skal feile når organisasjonsnummer er negativ streng', () => {
+      const result = hasValidOrgNumber('-12345678');
+      expect(result).toEqual('Ugyldig organisasjonsnummer. Organisasjonsnummer må være 9 siffer.');
+    });
   });
 });

--- a/packages/form-validators/src/validators.ts
+++ b/packages/form-validators/src/validators.ts
@@ -128,7 +128,7 @@ export const hasValidOrgNumber = (number: string | number): FormValidationResult
   if (Number.isNaN(Number(trimmedNumber))) {
     return invalidOrgNumberMessage();
   }
-  return trimmedNumber.length === 9 ? null : invalidOrgNumberMessage();
+  return /^\d{9}$/.test(trimmedNumber) ? null : invalidOrgNumberMessage();
 };
 
 export const hasValidOrgNumberOrFodselsnr = (number: string | number): FormValidationResult =>

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -4,6 +4,7 @@ export {
   formatCurrencyNoKr,
   removeSpacesFromNumber,
   parseCurrencyInput,
+  sanitizeNumericString,
 } from './src/currencyUtils';
 export {
   addDaysToDate,

--- a/packages/utils/src/currencyUtils.ts
+++ b/packages/utils/src/currencyUtils.ts
@@ -6,17 +6,19 @@ export const formatCurrencyWithKr = (value: number | string): string | undefined
 const NEGATIVE_SIGN = '\u2212';
 const DASH_SIGN = '-';
 
+export const sanitizeNumericString = (value: string): string =>
+  value
+    .replaceAll(/\s/g, '')
+    .replaceAll(',', '.')
+    .replaceAll(NEGATIVE_SIGN, DASH_SIGN)
+    .replaceAll(/[a-zA-ZæøåÆØÅ]/g, '');
+
 export const formatCurrencyNoKr = (value: string | number | undefined | null): string | undefined => {
   if (value === null || value === undefined) {
     return undefined;
   }
   // Fjerner mellomrom i tilfelle vi får inn tall med det
-  const newVal = value
-    .toString()
-    .replaceAll(/\s/g, '')
-    .replaceAll(',', '.')
-    .replaceAll(NEGATIVE_SIGN, DASH_SIGN)
-    .replaceAll(/[a-zA-ZæøåÆØÅ]/g, '');
+  const newVal = sanitizeNumericString(value.toString());
 
   if (Number.isNaN(Number(newVal))) {
     return undefined;
@@ -48,12 +50,7 @@ export const removeSpacesFromNumber = (input: number | string | undefined | null
 };
 
 export const parseCurrencyInput = (input: string | number): string => {
-  const inputNoSpace = input
-    .toString()
-    .replaceAll(/\s/g, '')
-    .replaceAll(',', '.')
-    .replaceAll(NEGATIVE_SIGN, DASH_SIGN)
-    .replaceAll(/[a-zA-ZæøåÆØÅ]/g, '');
+  const inputNoSpace = sanitizeNumericString(input.toString());
 
   if (inputNoSpace === '' || Number.isNaN(Number(inputNoSpace))) {
     return inputNoSpace;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,6 +2323,7 @@ __metadata:
     "@navikt/ft-config-eslint": "workspace:^"
     "@navikt/ft-config-typescript": "workspace:^"
     "@navikt/ft-config-vite": "workspace:^"
+    "@navikt/ft-form-validators": "workspace:^"
     "@navikt/ft-ui-komponenter": "workspace:^"
     "@navikt/ft-utils": "workspace:^"
     "@testing-library/dom": "npm:10.4.1"


### PR DESCRIPTION
## Endringer

- Refaktorer `RhfNumericField` med CSS-modul og forbedret logikk
- Legg til tester for `RhfNumericField`
- Oppdater stories for `RhfNumericField`
- Fiks `currencyUtils` og eksporter fra `utils`
- Oppdater `form-validators`

**Berørte pakker:** `ft-form-hooks`, `ft-form-validators`, `ft-utils`