### PR TITLE
FAGSYSTEM-431184: fjern aria-hidden som skjulte beløp for skjermlesarar

### DIFF
--- a/packages/ui-komponenter/src/KopierbarTekst.tsx
+++ b/packages/ui-komponenter/src/KopierbarTekst.tsx
@@ -27,7 +27,12 @@ export const KopierbarTekst = ({ tekst, children }: Props) => {
   };
   return (
     <Tooltip content={intl.formatMessage({ id: skalViseKopiert ? 'KopierbarTekst.Kopiert' : 'KopierbarTekst.Kopier' })}>
-      <span aria-hidden="true" onClick={copy}>
+      <span role="button" tabIndex={0} onClick={copy} onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          copy(e as unknown as React.MouseEvent<HTMLSpanElement>);
+        }
+      }}>
         {children ?? tekst}
       </span>
     </Tooltip>

--- a/packages/ui-komponenter/src/KopierbarTekst.tsx
+++ b/packages/ui-komponenter/src/KopierbarTekst.tsx
@@ -16,7 +16,7 @@ export const KopierbarTekst = ({ tekst, children }: Props) => {
   if (!tekst) {
     return children;
   }
-  const copy: React.MouseEventHandler<HTMLSpanElement> = async (e): Promise<void> => {
+  const copy = async (e: React.SyntheticEvent<HTMLSpanElement>): Promise<void> => {
     e.stopPropagation();
     await navigator.clipboard.writeText(tekst);
     setSkalViseKopiert(true);
@@ -30,7 +30,7 @@ export const KopierbarTekst = ({ tekst, children }: Props) => {
       <span role="button" tabIndex={0} onClick={copy} onKeyDown={e => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          copy(e as unknown as React.MouseEvent<HTMLSpanElement>);
+          copy(e);
         }
       }}>
         {children ?? tekst}


### PR DESCRIPTION
https://jira.adeo.no/browse/FAGSYSTEM-431184

KopierbarTekst brukte aria-hidden="true" på span-elementet som wrappa alt innhald. Sidan BeløpLabel bruker KopierbarTekst vart alle beløp (månedsinntekt, årsinntekt osv.) usynlege for JAWS.

- Fjerna aria-hidden="true"
- La til role="button" og tabIndex={0} for tastaturstøtte
- La til onKeyDown for kopiering med Enter/mellomrom