### PR TITLE
FAGSYSTEM-431184: la beløpet vere det tilgjengelege namnet i KopierbarTekst

### DIFF
--- a/packages/ui-komponenter/src/KopierbarTekst.tsx
+++ b/packages/ui-komponenter/src/KopierbarTekst.tsx
@@ -16,7 +16,7 @@ export const KopierbarTekst = ({ tekst, children }: Props) => {
   if (!tekst) {
     return children;
   }
-  const copy = async (e: React.SyntheticEvent<HTMLSpanElement>): Promise<void> => {
+  const copy: React.MouseEventHandler<HTMLSpanElement> = async (e): Promise<void> => {
     e.stopPropagation();
     await navigator.clipboard.writeText(tekst);
     setSkalViseKopiert(true);
@@ -27,14 +27,7 @@ export const KopierbarTekst = ({ tekst, children }: Props) => {
   };
   return (
     <Tooltip content={intl.formatMessage({ id: skalViseKopiert ? 'KopierbarTekst.Kopiert' : 'KopierbarTekst.Kopier' })}>
-      <span role="button" tabIndex={0} onClick={copy} onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          copy(e);
-        }
-      }}>
-        {children ?? tekst}
-      </span>
+      <span onClick={copy}>{children ?? tekst}</span>
     </Tooltip>
   );
 };

--- a/packages/ui-komponenter/src/KopierbarTekst.tsx
+++ b/packages/ui-komponenter/src/KopierbarTekst.tsx
@@ -27,6 +27,7 @@ export const KopierbarTekst = ({ tekst, children }: Props) => {
   };
   return (
     <Tooltip content={intl.formatMessage({ id: skalViseKopiert ? 'KopierbarTekst.Kopiert' : 'KopierbarTekst.Kopier' })}>
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <span onClick={copy}>{children ?? tekst}</span>
     </Tooltip>
   );


### PR DESCRIPTION
Denne vart ikkje heilt korrekt i førre forsøk, sjå kommentar på https://jira.adeo.no/browse/FAGSYSTEM-431184

Tooltip-en sin tekst (Klikk for å kopiere) overstyrte det tilgjengelege namnet på knappen som vart introdusert i f5b0946, slik at JAWS las opp kopier-hintet i staden for sjølve beløpet.

Fjernar role=button, tabIndex og onKeyDown, slik at span-en er rein tekst. Skjermlesarar les då beløpet normalt. Mus-brukarar kan framleis klikke for å kopiere; tastatur- og skjermlesarbrukarar kan markere og kopiere teksten på vanleg måte.