### PR TITLE
ci: bruk felles knip-action i PR-validering

### DIFF
--- a/.github/workflows/valider-pull-request.yml
+++ b/.github/workflows/valider-pull-request.yml
@@ -47,36 +47,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: navikt/fp-gha-workflows/.github/actions/setup-yarnrc@main
-        with:
-          npmAuthToken: ${{ secrets.READER_TOKEN }}
-
-      - uses: actions/setup-node@v6.4.0
-        with:
-          node-version: 26.1.0
-          cache: 'yarn'
-
-      - name: Installere dependencies
-        run: yarn install --immutable
-
       - name: Run knip
-        run: |
-          yarn knip --no-exit-code --reporter=markdown > knip-report.md
-          cat knip-report.md > $GITHUB_STEP_SUMMARY
-
-      - name: Delete previous comments from knip
-        continue-on-error: true
-        run: gh pr comment ${{ github.event.pull_request.number }} --delete-last --yes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Post knip report
-        run: |
-          number_of_words=$(wc -w < knip-report.md)
-          if [ $number_of_words -gt 3 ]; then
-            gh pr comment ${{ github.event.pull_request.number }} --body-file knip-report.md
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: navikt/fp-gha-workflows/.github/actions/knip-it@main
+        with:
+          npm-auth-token: ${{ secrets.READER_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-manager: 'yarn'
+          node-version: 26.1.0


### PR DESCRIPTION
## Sammendrag
- Bytter manuell knip-kjøring i PR-validering med felles `knip-it` action.
- Sender npm-token, GitHub-token, yarn og Node 26.1.0 videre til actionen.
