### PR TITLE
fix: Legger til horisontall scroll for tabs i fakta berergning ved ma…

### DIFF
--- a/packages/fakta-beregning/src/BeregningFaktaIndex.tsx
+++ b/packages/fakta-beregning/src/BeregningFaktaIndex.tsx
@@ -123,6 +123,7 @@ export const BeregningFaktaIndex = ({
   const aktivtBeregningsgrunnlag = beregningsgrunnlag[aktivtBeregningsgrunnlagIndeks];
 
   const aktiveAvklaringsBehov = aktivtBeregningsgrunnlag.avklaringsbehov;
+  const komprimerTabs = skalBrukeTabs && beregningsgrunnlag.length > 5;
 
   return (
     <RawIntlProvider value={intl}>
@@ -143,6 +144,8 @@ export const BeregningFaktaIndex = ({
             <Tabs
               value={aktivtBeregningsgrunnlagIndeks.toString()}
               onChange={(clickedIndex: string) => setAktivtBeregningsgrunnlagIndeks(Number(clickedIndex))}
+              size={komprimerTabs ? 'small' : 'medium'}
+              className={komprimerTabs ? styles.tabScroll : undefined}
             >
               <Tabs.List>
                 {beregningsgrunnlag.map((currentBeregningsgrunnlag, currentBeregningsgrunnlagIndex) => (

--- a/packages/fakta-beregning/src/beregningFaktaIndex.module.css
+++ b/packages/fakta-beregning/src/beregningFaktaIndex.module.css
@@ -5,3 +5,15 @@
 .container {
   width: fit-content;
 }
+
+@media (width >= 1336px) {
+  .tabScroll {
+    width: clamp(670px, 50vw, 1220px);
+  }
+}
+
+@media (width < 1336px) {
+  .tabScroll {
+    max-width: 80vw;
+  }
+}


### PR DESCRIPTION
…nge perioder

This pull request improves the usability of the tabs in the `BeregningFaktaIndex` component when handling a large number of calculation bases. The main change is to introduce a more compact and scrollable tab layout when there are more than five calculation bases, ensuring the UI remains user-friendly and accessible across different screen sizes.

**UI/UX Improvements for Tabs:**

* Added logic in `BeregningFaktaIndex.tsx` to use a smaller tab size and apply a scrollable style when there are more than five calculation bases, enhancing usability for large datasets. [[1]](diffhunk://#diff-8be728ff1d3f1d6428e97355242ec86d10ae7c176f6b2e48c3d6000b8bb4150bR126) [[2]](diffhunk://#diff-8be728ff1d3f1d6428e97355242ec86d10ae7c176f6b2e48c3d6000b8bb4150bR147-R148)
* Introduced responsive CSS rules in `beregningFaktaIndex.module.css` to define the width and scrolling behavior of the tabs, adapting to different screen widths for optimal display.