### PR TITLE
TFP-6367: legg til automatisk punktum i RhfDatepicker

### DIFF
--- a/packages/form-hooks/src/RhfDatepicker/RhfDatepicker.spec.tsx
+++ b/packages/form-hooks/src/RhfDatepicker/RhfDatepicker.spec.tsx
@@ -66,4 +66,22 @@ describe('RhfDatepicker', () => {
       dato: '2020-02-01',
     });
   });
+
+  it('skal automatisk sette inn punktum når brukeren skriver 8 sifre', async () => {
+    const onSubmit = vi.fn();
+    const { container } = render(<TestForm onSubmit={onSubmit} />);
+
+    const input = within(container).getByLabelText('Dato');
+    await userEvent.type(input, '26082025');
+
+    expect(input).toHaveValue('26.08.2025');
+
+    fireEvent.blur(input);
+    await userEvent.click(within(container).getByRole('button', { name: 'Submit' }));
+
+    expect(onSubmit).toHaveBeenCalled();
+    expect(onSubmit.mock.calls[0][0]).toEqual({
+      dato: '2025-08-26',
+    });
+  });
 });

--- a/packages/form-hooks/src/RhfDatepicker/RhfDatepicker.spec.tsx
+++ b/packages/form-hooks/src/RhfDatepicker/RhfDatepicker.spec.tsx
@@ -84,4 +84,16 @@ describe('RhfDatepicker', () => {
       dato: '2025-08-26',
     });
   });
+
+  it('skal formatere på nytt når samme 8 sifre erstatter en allerede formatert dato', async () => {
+    const { container } = render(<TestForm onSubmit={vi.fn()} />);
+
+    const input = within(container).getByLabelText('Dato');
+    await userEvent.type(input, '26082025');
+    expect(input).toHaveValue('26.08.2025');
+
+    // Bruker markerer alt og limer inn den samme sifferrekken – skal fortsatt få punktum
+    fireEvent.change(input, { target: { value: '26082025' } });
+    expect(input).toHaveValue('26.08.2025');
+  });
 });

--- a/packages/form-hooks/src/RhfDatepicker/RhfDatepicker.tsx
+++ b/packages/form-hooks/src/RhfDatepicker/RhfDatepicker.tsx
@@ -81,17 +81,19 @@ export const RhfDatepicker = <T extends FieldValues>({
   const onChangeInput = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const parserFormats = inputFormats.length > 0 ? inputFormats : [DDMMYYYY_DATE_FORMAT];
-      const parsedDate = dayjs(event.target.value, parserFormats, true);
-      const validDate = parsedDate.isValid();
-      const verdi = validDate ? parsedDate.format(ISO_DATE_FORMAT) : event.target.value;
+      const { inputVerdi, dato } = formatDateInput({
+        nyVerdi: event.target.value,
+        forrigeVerdi: fieldValue,
+        parserFormats,
+      });
 
-      setFieldValue(event.target.value);
+      setFieldValue(inputVerdi);
       if (onChange) {
-        onChange(verdi);
+        onChange(dato);
       }
-      field.onChange(verdi);
+      field.onChange(dato);
     },
-    [setFieldValue, onChange, field, inputFormats],
+    [setFieldValue, onChange, field, inputFormats, fieldValue],
   );
 
   if (readOnly) {
@@ -128,4 +130,32 @@ export const RhfDatepicker = <T extends FieldValues>({
       />
     </DatePicker>
   );
+};
+
+const formatDateInput = ({
+  nyVerdi,
+  forrigeVerdi,
+  parserFormats,
+}: {
+  nyVerdi: string;
+  forrigeVerdi: string;
+  parserFormats: string[];
+}): { inputVerdi: string; dato: string } => {
+  const direkteParset = dayjs(nyVerdi, parserFormats, true);
+  if (direkteParset.isValid()) {
+    return { inputVerdi: nyVerdi, dato: direkteParset.format(ISO_DATE_FORMAT) };
+  }
+
+  // Setter automatisk inn punktum når brukeren skriver 8 sifre: "26082025" -> "26.08.2025"
+  const tall = nyVerdi.replace(/\D/g, '');
+  const forrigeTall = forrigeVerdi.replace(/\D/g, '');
+  if (tall.length === 8 && tall !== forrigeTall) {
+    const formatert = `${tall.slice(0, 2)}.${tall.slice(2, 4)}.${tall.slice(4, 8)}`;
+    const parset = dayjs(formatert, DDMMYYYY_DATE_FORMAT, true);
+    if (parset.isValid()) {
+      return { inputVerdi: formatert, dato: parset.format(ISO_DATE_FORMAT) };
+    }
+  }
+
+  return { inputVerdi: nyVerdi, dato: nyVerdi };
 };

--- a/packages/form-hooks/src/RhfDatepicker/RhfDatepicker.tsx
+++ b/packages/form-hooks/src/RhfDatepicker/RhfDatepicker.tsx
@@ -146,10 +146,9 @@ const formatDateInput = ({
     return { inputVerdi: nyVerdi, dato: direkteParset.format(ISO_DATE_FORMAT) };
   }
 
-  // Setter automatisk inn punktum når brukeren skriver 8 sifre: "26082025" -> "26.08.2025"
+  // Setter automatisk inn punktum når brukeren skriver/limer inn 8 sifre: "26082025" -> "26.08.2025"
   const tall = nyVerdi.replace(/\D/g, '');
-  const forrigeTall = forrigeVerdi.replace(/\D/g, '');
-  if (tall.length === 8 && tall !== forrigeTall) {
+  if (tall.length === 8 && nyVerdi !== forrigeVerdi) {
     const formatert = `${tall.slice(0, 2)}.${tall.slice(2, 4)}.${tall.slice(4, 8)}`;
     const parset = dayjs(formatert, DDMMYYYY_DATE_FORMAT, true);
     if (parset.isValid()) {


### PR DESCRIPTION
Når brukeren skriver 8 sifre (f.eks. 26082025) settes det automatisk inn punktum slik at verdien blir 26.08.2025.

Løysing er rappa fra https://github.com/navikt/foreldrepengesoknad/blob/master/packages/form-hooks/src/form-wrappers/RhfDatepicker.tsx

https://jira.adeo.no/browse/TFP-6367