### PR TITLE
refactor: erstatt inline class-join med delt classNames-helper

### DIFF
--- a/packages/form-hooks/src/RhfCheckbox/RhfCheckbox.tsx
+++ b/packages/form-hooks/src/RhfCheckbox/RhfCheckbox.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useMemo } from 'react';
 import { type FieldValues, useController, type UseControllerProps, useFormContext } from 'react-hook-form';
 
 import { Checkbox, type CheckboxProps, ErrorMessage } from '@navikt/ds-react';
+import { classNames } from '@navikt/ft-utils';
 
 import { getError, getValidationRules, type ValidationReturnType } from '../formUtils';
 
@@ -60,7 +61,7 @@ export const RhfCheckbox = <T extends FieldValues>({
             onClick();
           }
         }}
-        className={[className, styles.noReadOnlyIcon].filter(Boolean).join(' ')}
+        className={classNames(className, styles.noReadOnlyIcon)}
         {...rest}
       >
         {label}

--- a/packages/form-hooks/src/RhfCheckbox/RhfCheckbox.tsx
+++ b/packages/form-hooks/src/RhfCheckbox/RhfCheckbox.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useMemo } from 'react';
 import { type FieldValues, useController, type UseControllerProps, useFormContext } from 'react-hook-form';
 
 import { Checkbox, type CheckboxProps, ErrorMessage } from '@navikt/ds-react';
+
 import { classNames } from '@navikt/ft-utils';
 
 import { getError, getValidationRules, type ValidationReturnType } from '../formUtils';

--- a/packages/form-hooks/src/RhfCheckboxGroup/RhfCheckboxGroup.tsx
+++ b/packages/form-hooks/src/RhfCheckboxGroup/RhfCheckboxGroup.tsx
@@ -11,6 +11,7 @@ import {
 import { Checkbox, CheckboxGroup, type CheckboxGroupProps, HStack } from '@navikt/ds-react';
 
 import { EditedIcon } from '@navikt/ft-ui-komponenter';
+import { classNames } from '@navikt/ft-utils';
 
 import { getError, getValidationRules, type ValidationReturnType } from '../formUtils';
 
@@ -78,7 +79,7 @@ export const RhfCheckboxGroup = <TFieldValues extends FieldValues, TName extends
       }
       readOnly={readOnly}
       error={getError(errors, name)}
-      className={[className, styles.noReadOnlyIcon].filter(Boolean).join(' ')}
+      className={classNames(className, styles.noReadOnlyIcon)}
       {...rest}
     >
       {children}

--- a/packages/form-hooks/src/RhfRadioGroup/RhfRadioGroup.tsx
+++ b/packages/form-hooks/src/RhfRadioGroup/RhfRadioGroup.tsx
@@ -11,6 +11,7 @@ import {
 import { HStack, RadioGroup, type RadioGroupProps } from '@navikt/ds-react';
 
 import { EditedIcon } from '@navikt/ft-ui-komponenter';
+import { classNames } from '@navikt/ft-utils';
 
 import { getError, getValidationRules, type ValidationReturnType } from '../formUtils';
 
@@ -70,7 +71,7 @@ export const RhfRadioGroup = <TFieldValues extends FieldValues, TName extends Fi
         }
         field.onChange(value);
       }}
-      className={[className, styles.noReadOnlyIcon].filter(Boolean).join(' ')}
+      className={classNames(className, styles.noReadOnlyIcon)}
       {...rest}
     >
       {children}

--- a/packages/plattform-komponenter/src/ProcessMenu/components/Step.tsx
+++ b/packages/plattform-komponenter/src/ProcessMenu/components/Step.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { BodyShort, Tooltip } from '@navikt/ds-react';
+
 import { classNames } from '@navikt/ft-utils';
 
 import { StepIcon } from './StepIcon';

--- a/packages/plattform-komponenter/src/ProcessMenu/components/Step.tsx
+++ b/packages/plattform-komponenter/src/ProcessMenu/components/Step.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { BodyShort, Tooltip } from '@navikt/ds-react';
+import { classNames } from '@navikt/ft-utils';
 
 import { StepIcon } from './StepIcon';
 import { StepType } from './StepType';
@@ -38,14 +39,12 @@ export const Step = ({
     }
   };
 
-  const stepIndicatorCls = [
+  const stepIndicatorCls = classNames(
     styles.step__button,
     styles[type],
     isActive && styles['active'],
     usePartialStatus && styles['partial'],
-  ]
-    .filter(Boolean)
-    .join(' ');
+  );
 
   return (
     <li key={label} className={styles.step} aria-current={isActive ? 'step' : undefined}>
@@ -58,7 +57,7 @@ export const Step = ({
         </button>
       </Tooltip>
       {isActive && (
-        <div className={[stepArrowContainerStyle, styles['step__arrow-container']].filter(Boolean).join(' ')} />
+        <div className={classNames(stepArrowContainerStyle, styles['step__arrow-container'])} />
       )}
     </li>
   );

--- a/packages/prosess-beregningsgrunnlag/src/BeregningsgrunnlagProsessIndex.tsx
+++ b/packages/prosess-beregningsgrunnlag/src/BeregningsgrunnlagProsessIndex.tsx
@@ -6,7 +6,7 @@ import { BodyShort, Heading, VStack } from '@navikt/ds-react';
 
 import { SideMenu } from '@navikt/ft-plattform-komponenter';
 import type { ArbeidsgiverOpplysningerPerId, Beregningsgrunnlag, StandardProsessPanelProps } from '@navikt/ft-types';
-import { createIntl, classNames, dateFormat } from '@navikt/ft-utils';
+import { classNames, createIntl, dateFormat } from '@navikt/ft-utils';
 
 import { BeregningFP } from './components/BeregningFP';
 import type { BeregningFormValues } from './types/BeregningFormValues';

--- a/packages/prosess-beregningsgrunnlag/src/BeregningsgrunnlagProsessIndex.tsx
+++ b/packages/prosess-beregningsgrunnlag/src/BeregningsgrunnlagProsessIndex.tsx
@@ -6,7 +6,7 @@ import { BodyShort, Heading, VStack } from '@navikt/ds-react';
 
 import { SideMenu } from '@navikt/ft-plattform-komponenter';
 import type { ArbeidsgiverOpplysningerPerId, Beregningsgrunnlag, StandardProsessPanelProps } from '@navikt/ft-types';
-import { createIntl, dateFormat } from '@navikt/ft-utils';
+import { createIntl, classNames, dateFormat } from '@navikt/ft-utils';
 
 import { BeregningFP } from './components/BeregningFP';
 import type { BeregningFormValues } from './types/BeregningFormValues';
@@ -118,9 +118,10 @@ export const BeregningsgrunnlagProsessIndex = ({
   const [aktivtBeregningsgrunnlagIndeks, setAktivtBeregningsgrunnlagIndeks] = useState(0);
 
   const menyProps = lagMenyProps(listeMedGrunnlag, beregningsgrunnlagsvilkar);
-  const mainContainerClassnames = [styles.mainContainer, skalBrukeSidemeny && styles['mainContainer--withSideMenu']]
-    .filter(Boolean)
-    .join(' ');
+  const mainContainerClassnames = classNames(
+    styles.mainContainer,
+    skalBrukeSidemeny && styles['mainContainer--withSideMenu'],
+  );
 
   useEffect(() => {
     const førsteSkjæringstidspunktMedAksjonspunktIndex = menyProps.findIndex(

--- a/packages/ui-komponenter/src/AvsnittSkiller.tsx
+++ b/packages/ui-komponenter/src/AvsnittSkiller.tsx
@@ -1,3 +1,5 @@
+import { classNames } from '@navikt/ft-utils';
+
 import styles from './avsnittSkiller.module.css';
 
 type Props = {
@@ -20,7 +22,7 @@ export const AvsnittSkiller = ({
   <>
     {spaceAbove && <div style={{ marginBottom: '32px' }} />}
     <div
-      className={[className, leftPanel && styles.leftPanel, rightPanel && styles.rightPanel].filter(Boolean).join(' ')}
+      className={classNames(className, leftPanel && styles.leftPanel, rightPanel && styles.rightPanel)}
     >
       <div className={dividerParagraf ? styles.dividerParagraf : styles.divider} />
     </div>

--- a/packages/ui-komponenter/src/BorderBox.tsx
+++ b/packages/ui-komponenter/src/BorderBox.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { Box } from '@navikt/ds-react';
+
 import { classNames } from '@navikt/ft-utils';
 
 import styles from './borderBox.module.css';

--- a/packages/ui-komponenter/src/BorderBox.tsx
+++ b/packages/ui-komponenter/src/BorderBox.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { Box } from '@navikt/ds-react';
+import { classNames } from '@navikt/ft-utils';
 
 import styles from './borderBox.module.css';
 
@@ -16,7 +17,7 @@ interface Props {
  * Valideringskomponent. Visar en box kring noe som skall fikses.
  */
 export const BorderBox = ({ error = false, className, children }: Props) => (
-  <Box padding="space-16" className={[styles.borderbox, error && styles.error, className].filter(Boolean).join(' ')}>
+  <Box padding="space-16" className={classNames(styles.borderbox, error && styles.error, className)}>
     {children}
   </Box>
 );

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,4 +1,5 @@
 export { forhandsvisDokument } from './src/browserUtils';
+export { classNames } from './src/classNames';
 export {
   formatCurrencyWithKr,
   formatCurrencyNoKr,

--- a/packages/utils/src/classNames.spec.ts
+++ b/packages/utils/src/classNames.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { classNames } from './classNames';
+
+describe('classNames', () => {
+  it('skal slå saman alle sanne klassenamn med mellomrom', () => {
+    expect(classNames('a', 'b', 'c')).toBe('a b c');
+  });
+
+  it('skal hoppe over falske verdiar', () => {
+    expect(classNames('a', false, undefined, null, 'b')).toBe('a b');
+  });
+
+  it('skal returnere tom streng når ingen klassar er sanne', () => {
+    expect(classNames(false, undefined, null)).toBe('');
+  });
+
+  it('skal støtte betinga klassar via &&', () => {
+    const lagTabKlasse = (aktiv: boolean, error: boolean) => classNames('tab', aktiv && 'aktiv', error && 'error');
+    expect(lagTabKlasse(true, false)).toBe('tab aktiv');
+    expect(lagTabKlasse(false, true)).toBe('tab error');
+  });
+});

--- a/packages/utils/src/classNames.ts
+++ b/packages/utils/src/classNames.ts
@@ -1,0 +1,3 @@
+type ClassValue = string | false | null | undefined;
+
+export const classNames = (...klasser: ClassValue[]): string => klasser.filter(Boolean).join(' ');


### PR DESCRIPTION
Legg til ein gjenbrukbar classNames-helper i @navikt/ft-utils og bytt ut inline [...].filter(Boolean).join(' ')-mønsteret i ui-komponenter, form-hooks, plattform-komponenter og prosess-beregningsgrunnlag.