### PR TITLE
TFP-6481 Fiks avkuttet ECharts-tooltip i RegisterInntekter

### DIFF
--- a/packages/prosess-beregning/src/components/registerinntekter/graf/RegisterinntekterGraf.tsx
+++ b/packages/prosess-beregning/src/components/registerinntekter/graf/RegisterinntekterGraf.tsx
@@ -68,6 +68,7 @@ export const RegisterinntekterGraf = ({
           tooltip: {
             axisPointer: { type: 'shadow' },
             trigger: 'axis',
+            appendToBody: true,
             textStyle,
             borderColor: getAkselVariable('--ax-border-neutral-subtleA'),
             borderRadius: 12,


### PR DESCRIPTION
## Problem
I hover-popoveren i ECharts-grafen for RegisterInntekter ble deler av tooltip-innholdet skjult. Tooltip rendres som HTML inni chart-containeren, og i denne visningen havner den i et layout-/stacking-kontekst (FaktaBoks/ExpansionCard i grid) som gjør at innhold kan bli klippet.

Konsekvensen er at saksbehandler ikke alltid ser hele forklaringen og beløpene i hover-visningen.

## Løsning
- Setter tooltip.appendToBody: true i Registerinntekter-grafen.
- Da rendres tooltip på document.body i stedet for inni chart-containeren.
- Dette gjør at tooltip ikke blir klippet av omkringliggende containere.

## Før
<img width="715" height="615" alt="Screenshot 2026-07-28 at 15 18 27" src="https://github.com/user-attachments/assets/d5ea0047-6516-41c9-be40-ba23c48cfe99" />


## Etter
<img width="715" height="615" alt="Screenshot 2026-07-28 at 15 19 40" src="https://github.com/user-attachments/assets/7deb168c-299a-4cee-b278-c3beda7d06ee" />
